### PR TITLE
Make header controls more accessible

### DIFF
--- a/src/components/Controls/single-controls/LangControl/LangControl.tsx
+++ b/src/components/Controls/single-controls/LangControl/LangControl.tsx
@@ -118,6 +118,9 @@ const LangControl = (props: ControlProps) => {
                 tooltipText={t('lang-text')}
                 icon={Globe}
                 popupPosition={popupPosition}
+                buttonExtraProps={{
+                    'aria-expanded': popupState.visible,
+                }}
                 isTooltipHidden={popupState.visible}
             />
         </Popover>

--- a/src/components/Feedback/Feedback.tsx
+++ b/src/components/Feedback/Feedback.tsx
@@ -114,6 +114,8 @@ const Feedback: React.FC<FeedbackProps> = (props) => {
         [onSendFeedback, setInnerState, dislikeSuccessPopup, hideFeedbackPopups],
     );
 
+    const isDislikePopupVisible = dislikeSuccessPopup.visible || dislikeVariantsPopup.visible;
+
     return (
         <React.Fragment>
             <ControlsLayout view={view}>
@@ -122,12 +124,14 @@ const Feedback: React.FC<FeedbackProps> = (props) => {
                     view={view}
                     onClick={onChangeLike}
                     isLiked={innerState === FeedbackType.like}
+                    isPopupVisible={likeSuccessPopup.visible}
                 />
                 <DislikeControl
                     ref={dislikeControlRef}
                     view={view}
                     onClick={onChangeDislike}
                     isDisliked={innerState === FeedbackType.dislike}
+                    isPopupVisible={isDislikePopupVisible}
                 />
             </ControlsLayout>
             {likeControlRef.current && (

--- a/src/components/Feedback/controls/DislikeControl.tsx
+++ b/src/components/Feedback/controls/DislikeControl.tsx
@@ -12,6 +12,7 @@ import {FeedbackView} from '../Feedback';
 type DislikeControlProps = {
     isVerticalView?: boolean | undefined;
     isDisliked: boolean | undefined;
+    isPopupVisible: boolean;
     className?: string | undefined;
     view: FeedbackView | undefined;
     onClick: () => void;
@@ -20,35 +21,45 @@ type DislikeControlProps = {
 const b = block('dc-feedback');
 
 const DislikeControl = memo(
-    forwardRef<HTMLButtonElement, DislikeControlProps>(({isDisliked, view, onClick}, ref) => {
-        const {t} = useTranslation('feedback');
-        const {isVerticalView, controlClassName} = useContext(ControlsLayoutContext);
-        const tooltipText = isDisliked ? t('cancel-dislike-text') : t('dislike-text');
+    forwardRef<HTMLButtonElement, DislikeControlProps>(
+        ({isDisliked, isPopupVisible, view, onClick}, ref) => {
+            const {t} = useTranslation('feedback');
+            const {isVerticalView, controlClassName} = useContext(ControlsLayoutContext);
+            const tooltipText = isDisliked ? t('cancel-dislike-text') : t('dislike-text');
 
-        const Icon = isDisliked ? ThumbsDownFill : ThumbsDown;
+            const Icon = isDisliked ? ThumbsDownFill : ThumbsDown;
 
-        if (view === FeedbackView.Wide) {
+            if (view === FeedbackView.Wide) {
+                return (
+                    <Button
+                        view="normal"
+                        ref={ref}
+                        onClick={onClick}
+                        className={b('control', {view})}
+                    >
+                        <Button.Icon>
+                            <Icon width={14} height={14} />
+                        </Button.Icon>
+                        {t<string>('button-dislike-text')}
+                    </Button>
+                );
+            }
+
             return (
-                <Button view="normal" ref={ref} onClick={onClick} className={b('control', {view})}>
-                    <Button.Icon>
-                        <Icon width={14} height={14} />
-                    </Button.Icon>
-                    {t<string>('button-dislike-text')}
-                </Button>
+                <Control
+                    onClick={onClick}
+                    className={b('control', {view}, controlClassName)}
+                    isVerticalView={isVerticalView}
+                    tooltipText={tooltipText}
+                    ref={ref}
+                    icon={Icon}
+                    buttonExtraProps={{
+                        'aria-expanded': isPopupVisible,
+                    }}
+                />
             );
-        }
-
-        return (
-            <Control
-                onClick={onClick}
-                className={b('control', {view}, controlClassName)}
-                isVerticalView={isVerticalView}
-                tooltipText={tooltipText}
-                ref={ref}
-                icon={Icon}
-            />
-        );
-    }),
+        },
+    ),
 );
 
 DislikeControl.displayName = 'DislikeControl';

--- a/src/components/Feedback/controls/LikeControl.tsx
+++ b/src/components/Feedback/controls/LikeControl.tsx
@@ -13,6 +13,7 @@ import {FeedbackView} from '../Feedback';
 type LikeControlProps = {
     isVerticalView?: boolean | undefined;
     isLiked: boolean | undefined;
+    isPopupVisible: boolean;
     className?: string | undefined;
     view: FeedbackView | undefined;
     onClick: () => void;
@@ -22,42 +23,48 @@ type LikeControlProps = {
 const b = block('dc-feedback');
 
 const LikeControl = memo(
-    forwardRef<HTMLButtonElement, LikeControlProps>(({isLiked, view, onClick}, ref) => {
-        const {t} = useTranslation('feedback');
-        const {isVerticalView, popupPosition, controlClassName} = useContext(ControlsLayoutContext);
-        const tooltipText = isLiked ? t('cancel-like-text') : t('like-text');
+    forwardRef<HTMLButtonElement, LikeControlProps>(
+        ({isLiked, isPopupVisible, view, onClick}, ref) => {
+            const {t} = useTranslation('feedback');
+            const {isVerticalView, popupPosition, controlClassName} =
+                useContext(ControlsLayoutContext);
+            const tooltipText = isLiked ? t('cancel-like-text') : t('like-text');
 
-        const Icon = isLiked ? ThumbsUpFill : ThumbsUp;
+            const Icon = isLiked ? ThumbsUpFill : ThumbsUp;
 
-        if (view === FeedbackView.Wide) {
+            if (view === FeedbackView.Wide) {
+                return (
+                    <Button
+                        size="m"
+                        view="normal"
+                        ref={ref}
+                        onClick={onClick}
+                        className={b('control', {view})}
+                    >
+                        <Button.Icon>
+                            <Icon width={14} height={14} />
+                        </Button.Icon>
+                        {t<string>('button-like-text')}
+                    </Button>
+                );
+            }
+
             return (
-                <Button
-                    size="m"
-                    view="normal"
-                    ref={ref}
+                <Control
                     onClick={onClick}
-                    className={b('control', {view})}
-                >
-                    <Button.Icon>
-                        <Icon width={14} height={14} />
-                    </Button.Icon>
-                    {t<string>('button-like-text')}
-                </Button>
+                    className={b('control', {view}, controlClassName)}
+                    isVerticalView={isVerticalView}
+                    tooltipText={tooltipText}
+                    ref={ref}
+                    icon={Icon}
+                    popupPosition={popupPosition}
+                    buttonExtraProps={{
+                        'aria-expanded': isPopupVisible,
+                    }}
+                />
             );
-        }
-
-        return (
-            <Control
-                onClick={onClick}
-                className={b('control', {view}, controlClassName)}
-                isVerticalView={isVerticalView}
-                tooltipText={tooltipText}
-                ref={ref}
-                icon={Icon}
-                popupPosition={popupPosition}
-            />
-        );
-    }),
+        },
+    ),
 );
 
 LikeControl.displayName = 'LikeControl';

--- a/src/components/Subscribe/Subscribe.tsx
+++ b/src/components/Subscribe/Subscribe.tsx
@@ -29,43 +29,49 @@ export interface SubscribeProps {
 type SubscribeControlProps = {
     view: SubscribeView;
     onChangeSubscribe: () => void;
+    isPopupVisible: boolean;
 };
 
 const SubscribeControl = memo(
-    forwardRef<HTMLButtonElement, SubscribeControlProps>(({view, onChangeSubscribe}, ref) => {
-        const {isVerticalView, popupPosition, controlClassName, controlSize} =
-            useContext(ControlsLayoutContext);
-        const {t} = useTranslation('controls');
+    forwardRef<HTMLButtonElement, SubscribeControlProps>(
+        ({view, onChangeSubscribe, isPopupVisible}, ref) => {
+            const {isVerticalView, popupPosition, controlClassName, controlSize} =
+                useContext(ControlsLayoutContext);
+            const {t} = useTranslation('controls');
 
-        if (view === SubscribeView.Wide) {
+            if (view === SubscribeView.Wide) {
+                return (
+                    <Button
+                        view="flat-secondary"
+                        ref={ref}
+                        onClick={onChangeSubscribe}
+                        className={b('control', {view})}
+                    >
+                        <Button.Icon>
+                            <Envelope width={16} height={16} />
+                        </Button.Icon>
+                        {t<string>('button-Subscribe-text')}
+                    </Button>
+                );
+            }
+
             return (
-                <Button
-                    view="flat-secondary"
+                <Control
                     ref={ref}
                     onClick={onChangeSubscribe}
-                    className={b('control', {view})}
-                >
-                    <Button.Icon>
-                        <Envelope width={16} height={16} />
-                    </Button.Icon>
-                    {t<string>('button-Subscribe-text')}
-                </Button>
+                    size={controlSize}
+                    className={b('control', {view}, controlClassName)}
+                    isVerticalView={isVerticalView}
+                    tooltipText={t(`subscribe-text`)}
+                    icon={Envelope}
+                    popupPosition={popupPosition}
+                    buttonExtraProps={{
+                        'aria-expanded': isPopupVisible,
+                    }}
+                />
             );
-        }
-
-        return (
-            <Control
-                ref={ref}
-                onClick={onChangeSubscribe}
-                size={controlSize}
-                className={b('control', {view}, controlClassName)}
-                isVerticalView={isVerticalView}
-                tooltipText={t(`subscribe-text`)}
-                icon={Envelope}
-                popupPosition={popupPosition}
-            />
-        );
-    }),
+        },
+    ),
 );
 
 SubscribeControl.displayName = 'SubscribeControl';
@@ -109,6 +115,8 @@ const Subscribe = memo<SubscribeProps>((props) => {
         successPopup.open();
     }, [successPopup, variantsPopup]);
 
+    const isPopupVisible = successPopup.visible || variantsPopup.visible;
+
     return (
         <React.Fragment>
             <SubscribeControlsLayout view={view}>
@@ -116,6 +124,7 @@ const Subscribe = memo<SubscribeProps>((props) => {
                     ref={subscribeControlRef}
                     view={view}
                     onChangeSubscribe={onChangeSubscribe}
+                    isPopupVisible={isPopupVisible}
                 />
             </SubscribeControlsLayout>
             {successPopup.visible && subscribeControlRef.current && (


### PR DESCRIPTION
Task: https://github.com/orgs/diplodoc-platform/projects/2/views/1?pane=issue&itemId=55496124

1) "aria-label" already exists for all header controls. 
2) "aria-expanded" already exists only for settings controller.
3) Add "aria-expanded" for the rest of controllers (language, feedback, subscribe).

Before:

https://github.com/user-attachments/assets/230bdbf2-baef-44c5-86be-541efc8bf630



After:


https://github.com/user-attachments/assets/1de6b461-d26d-42c3-bc6f-98ddb8343349

  