### PR TITLE
Make table of content more accessible

### DIFF
--- a/src/components/TocItem/TocItem.tsx
+++ b/src/components/TocItem/TocItem.tsx
@@ -61,6 +61,7 @@ class TocItem extends React.Component<TocItemProps> {
                 className={b('link')}
                 onClick={expandable && href ? this.handleClick : undefined}
                 data-router-shallow
+                aria-current={active ? 'true' : undefined}
             >
                 {content}
             </a>


### PR DESCRIPTION
Task: https://github.com/orgs/diplodoc-platform/projects/2/views/1?pane=issue&itemId=55496124

Add the attribute aria-current="true" to the section of the table of contents (Toc component) that is currently open.

Before:

https://github.com/user-attachments/assets/343e66c4-6f25-4298-83a3-68fafe9f6311


After:

https://github.com/user-attachments/assets/6033ae1a-2ae9-4f95-a836-42d9be7cfff2

 

 