### PR TITLE
fix: sharebutton visible on desktop

### DIFF
--- a/demo/src/Components/DocPage/index.stories.tsx
+++ b/demo/src/Components/DocPage/index.stories.tsx
@@ -14,7 +14,7 @@ import {
 import {configure as configureUikit} from '@gravity-ui/uikit';
 import cn from 'bem-cn-lite';
 
-import {updateBodyClassName, useMobile} from '../utils';
+import {updateBodyClassName} from '../utils';
 
 import {getContent} from './data';
 import './index.scss';
@@ -224,9 +224,9 @@ const DocPageDemo = (
     const subscribe = useSubscribe();
     const bookmarks = useBookmarks();
     const notification = useNotification();
-    const mobileView = useMobile();
     const search = useSearchResults(args['Search'] || '');
     const pdf = usePdf(args['Pdf'] || '');
+    const mobileView = Boolean(args['Mobile']);
 
     const {lang} = langs;
     const {wideFormat, showMiniToc, theme, textSize} = settings;
@@ -290,6 +290,9 @@ export default {
     title: 'Pages/Document',
     component: DocPageDemo,
     argTypes: {
+        Mobile: {
+            control: 'boolean',
+        },
         Settings: {
             control: 'boolean',
         },

--- a/demo/src/Components/DocPage/index.stories.tsx
+++ b/demo/src/Components/DocPage/index.stories.tsx
@@ -14,7 +14,7 @@ import {
 import {configure as configureUikit} from '@gravity-ui/uikit';
 import cn from 'bem-cn-lite';
 
-import {updateBodyClassName} from '../utils';
+import {updateBodyClassName, useMobile} from '../utils';
 
 import {getContent} from './data';
 import './index.scss';
@@ -224,6 +224,7 @@ const DocPageDemo = (
     const subscribe = useSubscribe();
     const bookmarks = useBookmarks();
     const notification = useNotification();
+    const mobileView = useMobile();
     const search = useSearchResults(args['Search'] || '');
     const pdf = usePdf(args['Pdf'] || '');
 
@@ -246,8 +247,8 @@ const DocPageDemo = (
         theme,
         textSize,
         singlePage,
+        isMobile: mobileView,
     };
-
     Object.assign(
         props,
         ...[

--- a/demo/src/Components/LeadingPage/index.stories.tsx
+++ b/demo/src/Components/LeadingPage/index.stories.tsx
@@ -2,7 +2,7 @@ import React, {useEffect} from 'react';
 import {DocLeadingPage, DocLeadingPageData, Theme} from '@diplodoc/components';
 import cn from 'bem-cn-lite';
 
-import {updateBodyClassName} from '../utils';
+import {updateBodyClassName, useMobile} from '../utils';
 
 import pageContent from './page.json';
 
@@ -14,9 +14,9 @@ type Args = {
 };
 
 const DocLeadingPageDemo = (args: Args) => {
-    const isMobile = args['Mobile'];
     const theme = args['Theme'];
     const router = {pathname: '/docs/compute'};
+    const mobileView = useMobile();
 
     useEffect(() => {
         updateBodyClassName(theme);
@@ -27,6 +27,7 @@ const DocLeadingPageDemo = (args: Args) => {
             <div className={layoutBlock('content')}>
                 <DocLeadingPage
                     {...(pageContent as DocLeadingPageData)}
+                    isMobile={mobileView}
                     wideFormat={true}
                     router={router}
                 />

--- a/demo/src/Components/LeadingPage/index.stories.tsx
+++ b/demo/src/Components/LeadingPage/index.stories.tsx
@@ -2,7 +2,7 @@ import React, {useEffect} from 'react';
 import {DocLeadingPage, DocLeadingPageData, Theme} from '@diplodoc/components';
 import cn from 'bem-cn-lite';
 
-import {updateBodyClassName, useMobile} from '../utils';
+import {updateBodyClassName} from '../utils';
 
 import pageContent from './page.json';
 
@@ -16,7 +16,7 @@ type Args = {
 const DocLeadingPageDemo = (args: Args) => {
     const theme = args['Theme'];
     const router = {pathname: '/docs/compute'};
-    const mobileView = useMobile();
+    const mobileView = Boolean(args['Mobile']);
 
     useEffect(() => {
         updateBodyClassName(theme);

--- a/demo/src/Components/LeadingPage/index.stories.tsx
+++ b/demo/src/Components/LeadingPage/index.stories.tsx
@@ -23,7 +23,7 @@ const DocLeadingPageDemo = (args: Args) => {
     }, [theme]);
 
     return (
-        <div className={isMobile === 'true' ? 'mobile' : 'desktop'}>
+        <div className={mobileView ? 'mobile' : 'desktop'}>
             <div className={layoutBlock('content')}>
                 <DocLeadingPage
                     {...(pageContent as DocLeadingPageData)}

--- a/demo/src/Components/utils.ts
+++ b/demo/src/Components/utils.ts
@@ -1,5 +1,4 @@
 import {Theme} from '@diplodoc/components';
-import {useCallback, useEffect, useState} from 'react';
 
 export function updateBodyClassName(theme: Theme) {
     const bodyEl = document.body;
@@ -10,32 +9,4 @@ export function updateBodyClassName(theme: Theme) {
 
     bodyEl.classList.toggle('g-root_theme_light', theme === 'light');
     bodyEl.classList.toggle('g-root_theme_dark', theme === 'dark');
-}
-
-const isBrowser = () => typeof document !== 'undefined';
-
-function getMobileView() {
-    if (!isBrowser()) {
-        return false;
-    }
-
-    return document.body.clientWidth < 768;
-}
-
-export function useMobile() {
-    const [mobileView, setMobileView] = useState<boolean>(getMobileView());
-
-    const onResizeHandler = useCallback(() => {
-        setMobileView(getMobileView());
-    }, []);
-
-    useEffect(onResizeHandler, [onResizeHandler]);
-
-    useEffect(() => {
-        window.addEventListener('resize', onResizeHandler);
-
-        return () => window.removeEventListener('resize', onResizeHandler);
-    }, [onResizeHandler]);
-
-    return mobileView;
 }

--- a/demo/src/Components/utils.ts
+++ b/demo/src/Components/utils.ts
@@ -1,4 +1,5 @@
 import {Theme} from '@diplodoc/components';
+import {useCallback, useEffect, useState} from 'react';
 
 export function updateBodyClassName(theme: Theme) {
     const bodyEl = document.body;
@@ -9,4 +10,32 @@ export function updateBodyClassName(theme: Theme) {
 
     bodyEl.classList.toggle('g-root_theme_light', theme === 'light');
     bodyEl.classList.toggle('g-root_theme_dark', theme === 'dark');
+}
+
+const isBrowser = () => typeof document !== 'undefined';
+
+function getMobileView() {
+    if (!isBrowser()) {
+        return false;
+    }
+
+    return document.body.clientWidth < 768;
+}
+
+export function useMobile() {
+    const [mobileView, setMobileView] = useState<boolean>(getMobileView());
+
+    const onResizeHandler = useCallback(() => {
+        setMobileView(getMobileView());
+    }, []);
+
+    useEffect(onResizeHandler, [onResizeHandler]);
+
+    useEffect(() => {
+        window.addEventListener('resize', onResizeHandler);
+
+        return () => window.removeEventListener('resize', onResizeHandler);
+    }, [onResizeHandler]);
+
+    return mobileView;
 }

--- a/src/components/DocLeadingPage/DocLeadingPage.tsx
+++ b/src/components/DocLeadingPage/DocLeadingPage.tsx
@@ -9,6 +9,7 @@ import {DocPageTitle} from '../DocPageTitle';
 import {HTML} from '../HTML';
 import {Text} from '../Text';
 import {Notification, NotificationProps} from '../Notification';
+import {ShareButton} from '../ShareButton';
 
 import './DocLeadingPage.scss';
 
@@ -25,6 +26,7 @@ export interface DocLeadingPageProps extends DocLeadingPageData, NotificationPro
     tocTitleIcon?: React.ReactNode;
     useMainTag?: boolean;
     legacyToc?: boolean;
+    isMobile?: boolean;
 }
 
 export interface DocLinkProps {
@@ -118,6 +120,7 @@ export const DocLeadingPage: React.FC<DocLeadingPageProps> = ({
     legacyToc,
     notification,
     notificationCb,
+    isMobile,
 }) => {
     const modes = {
         'regular-page-width': !wideFormat,
@@ -138,6 +141,7 @@ export const DocLeadingPage: React.FC<DocLeadingPageProps> = ({
             <DocLayout.Center>
                 <Notification notification={notification} notificationCb={notificationCb} />
                 <ContentWrapper className={b('main')} useMainTag={useMainTag}>
+                    {isMobile && <ShareButton className={b('share-button')} title={title} />}
                     <DocPageTitle stage={toc.stage} className={b('title')}>
                         <HTML>{title}</HTML>
                     </DocPageTitle>

--- a/src/components/DocPage/DocPage.scss
+++ b/src/components/DocPage/DocPage.scss
@@ -184,11 +184,6 @@
         &:hover::before {
             background-color: transparent;
         }
-
-        // ShareButton in title is currently only available on mobile devices.
-        @media (min-width: map.get(variables.$screenBreakpoints, 'md')) {
-            display: none;
-        }
     }
 
     &__content {

--- a/src/components/DocPage/DocPage.tsx
+++ b/src/components/DocPage/DocPage.tsx
@@ -78,6 +78,7 @@ export interface DocPageProps extends DocPageData, DocSettings, NotificationProp
     pdfLink?: string;
     onMiniTocItemClick?: (event: MouseEvent) => void;
     useMainTag?: boolean;
+    isMobile?: boolean;
 }
 
 type DocPageInnerProps = InnerProps<DocPageProps, DocSettings>;
@@ -403,9 +404,9 @@ class DocPage extends React.Component<DocPageInnerProps, DocPageState> {
     }
 
     private renderTitle() {
-        const {title, headerHeight, meta, bookmarkedPage, onChangeBookmarkPage} = this.props;
+        const {title, meta, bookmarkedPage, onChangeBookmarkPage, isMobile} = this.props;
         const withBookmarks = onChangeBookmarkPage;
-        const withShare = Number(headerHeight) > 0 && !this.showMiniToc;
+        const withShare = isMobile;
 
         if (!title) {
             return null;


### PR DESCRIPTION
depends on diplodoc-platform/client#106

5 mo ago fix for share button was in css, but now with new "bundle systems" something happened.
class with g-button is primary instead of share-button class (fixing share button visibility on mobile)
Solution: use isMobile
Yeah, I can fix it via css, but it should be in js I think, because we reduce rendering time 🚀 

Also I updated demo (storybook) with isMobile support via useMobile hook
