### PR TITLE
fix: navigation button invisible when logo large

### DIFF
--- a/src/components/navigation/CustomNavigation/CustomNavigation.scss
+++ b/src/components/navigation/CustomNavigation/CustomNavigation.scss
@@ -32,7 +32,7 @@
 
     @media (max-width: map.get(variables.$screenBreakpoints, 'sm') - 1) {
         .pc-desktop-navigation__wrapper .pc-desktop-navigation__logo .pc-logo__icon {
-            max-width: calc(100vw - 131px);
+            max-width: 100%;
         }
     }
 }

--- a/src/components/navigation/CustomNavigation/CustomNavigation.scss
+++ b/src/components/navigation/CustomNavigation/CustomNavigation.scss
@@ -29,4 +29,10 @@
             }
         }
     }
+
+    @media (max-width: map.get(variables.$screenBreakpoints, 'sm') - 1) {
+        .pc-desktop-navigation__wrapper .pc-desktop-navigation__logo .pc-logo__icon {
+            max-width: calc(100vw - 131px);
+        }
+    }
 }


### PR DESCRIPTION
When logo large, buttons get outside of page, fixed by css max-width