### PR TITLE
feat: re-export _namedContext

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -36,6 +36,8 @@ export * from './components/VersionsSelect';
 
 export * from './components/navigation';
 
+export * from './contexts/_namedContext';
+
 export * from './config';
 export * from './models';
 export * from './constants';


### PR DESCRIPTION
Re-exported _namedContext for writing other contexts in client repository