### PR TITLE
Remove unused props interfaces in MiniToc component

### DIFF
--- a/src/components/MiniToc/MiniToc.tsx
+++ b/src/components/MiniToc/MiniToc.tsx
@@ -3,7 +3,6 @@ import block from 'bem-cn-lite';
 import clsx from 'clsx';
 
 import {useTranslation} from '../../hooks';
-import {DocHeadingItem, Router} from '../../models';
 import {FlatHeadingItem} from '../SubNavigation/hooks/useHeadingIntersectionObserver';
 
 import './MiniToc.scss';
@@ -11,20 +10,6 @@ import './MiniToc.scss';
 const b = block('dc-mini-toc');
 
 const overflownClassName = 'dc-mini-toc_overflowed';
-
-export interface MinitocProps {
-    headings: DocHeadingItem[];
-    router: Router;
-    headerHeight?: number;
-    onItemClick?: (event: MouseEvent) => void;
-    onActiveItemTitleChange?: (title: string) => void;
-}
-
-export interface MinitocSectionProps {
-    headings: DocHeadingItem[];
-    router: Router;
-    headerHeight?: number;
-}
 
 type MiniTocProps = {
     headings: readonly FlatHeadingItem[];


### PR DESCRIPTION
### Motivation

There are `MinitocProps` and `MinitocSectionProps` interfaces exported from `MiniToc.tsx` file. After short investigation it was found out that these interfaces are not referenced anywhere in the project. Looks like both of them were replaced by new `MiniTocProps` interface which was created when enhancing `MiniToc` component and old interfaces were mistakenly left undeleted.

### Changes description

Unused `MinitocProps` and `MinitocSectionProps` were removed from the `src/components/MiniToc/MiniToc.tsx` file.


