### PR TITLE
feat: added errorTitle to ErrorPage

### DIFF
--- a/demo/src/Components/ErrorPage/index.stories.tsx
+++ b/demo/src/Components/ErrorPage/index.stories.tsx
@@ -2,17 +2,23 @@ import React from 'react';
 import {ERROR_CODES, ErrorPage} from '@diplodoc/components';
 
 type Args = {
+    Title: string;
     Mobile: string;
     ErrorCode: string;
 };
 
 const ErrorPageDemo = (args: Args) => {
+    const title = args['Title'];
     const isMobile = args['Mobile'];
     const errorCode = args['ErrorCode'];
 
     return (
         <div className={isMobile === 'true' ? 'mobile' : 'desktop'}>
-            <ErrorPage code={Number(errorCode)} receiveAccessUrl={'Request access url'} />
+            <ErrorPage
+                code={Number(errorCode)}
+                receiveAccessUrl={'Request access url'}
+                errorTitle={title}
+            />
         </div>
     );
 };
@@ -21,6 +27,9 @@ export default {
     title: 'Pages/Error',
     component: ErrorPageDemo,
     argTypes: {
+        Title: {
+            control: 'text',
+        },
         Mobile: {
             control: 'boolean',
         },
@@ -33,6 +42,7 @@ export default {
 
 export const Error = {
     args: {
+        Title: '',
         Mobile: false,
         ErrorCode: ERROR_CODES,
     },

--- a/src/components/ErrorPage/ErrorPage.tsx
+++ b/src/components/ErrorPage/ErrorPage.tsx
@@ -20,6 +20,7 @@ export interface ErrorPageProps {
     homeUrl?: string;
     receiveAccessUrl?: string;
     links?: LinkType[];
+    errorTitle?: string;
 }
 
 const ErrorPage: React.FC<ErrorPageProps> = ({
@@ -28,6 +29,7 @@ const ErrorPage: React.FC<ErrorPageProps> = ({
     receiveAccessUrl,
     pageGroup,
     links,
+    errorTitle,
 }) => {
     let title;
     let description;
@@ -99,7 +101,7 @@ const ErrorPage: React.FC<ErrorPageProps> = ({
             />
             <h1 className={b('code')}>{t('label_title-code', {code})}</h1>
             <h2 className={b('title')}>
-                {title}
+                {errorTitle || title}
                 {links && links.length > 0 && `. ${t('label_subtext')}`}
             </h2>
             <p className={b('description')}>{description}</p>


### PR DESCRIPTION
The ErrorPage component now accepts an errorTitle in props, which replaces the default title