### PR TITLE
fix: update ru translation for article updates

### DIFF
--- a/src/components/Contributors/Contributors.tsx
+++ b/src/components/Contributors/Contributors.tsx
@@ -14,16 +14,25 @@ export interface ContributorsProps {
     users: Contributor[];
     onlyAuthor?: boolean;
     isAuthor?: boolean;
+    hasAuthor?: boolean;
     translationName?: string;
 }
 
 const Contributors: React.FC<ContributorsProps> = (props) => {
-    const {users, onlyAuthor = false, isAuthor = false, translationName = 'contributors'} = props;
+    const {
+        users,
+        onlyAuthor = false,
+        isAuthor = false,
+        hasAuthor = true,
+        translationName = 'contributors',
+    } = props;
     const {t} = useTranslation(translationName);
+
+    const titleKey = !isAuthor && !hasAuthor ? 'no-author-title' : 'title';
 
     return (
         <div className={b()}>
-            <div className={b('title')}>{t('title')}</div>
+            <div className={b('title')}>{t(titleKey)}</div>
             <ContributorAvatars contributors={users} isAuthor={isAuthor} onlyAuthor={onlyAuthor} />
         </div>
     );

--- a/src/components/DocPage/DocPage.tsx
+++ b/src/components/DocPage/DocPage.tsx
@@ -458,9 +458,11 @@ class DocPage extends React.Component<DocPageInnerProps, DocPageState> {
             return null;
         }
 
+        const hasAuthor = isContributor(meta?.author);
+
         const author = this.renderAuthor(!meta?.contributors?.length);
-        const contributors = this.renderContributors();
-        const updatedAt = this.renderUpdatedAt(meta?.updatedAt);
+        const contributors = this.renderContributors(hasAuthor);
+        const updatedAt = this.renderUpdatedAt(meta?.updatedAt, hasAuthor);
 
         return (
             <div className={b('page-contributors')}>
@@ -471,12 +473,12 @@ class DocPage extends React.Component<DocPageInnerProps, DocPageState> {
         );
     }
 
-    private renderUpdatedAt(updatedAt?: string) {
+    private renderUpdatedAt(updatedAt?: string, hasAuthor = false) {
         if (!updatedAt) {
             return null;
         }
 
-        return <UpdatedAtDate updatedAt={updatedAt} />;
+        return <UpdatedAtDate updatedAt={updatedAt} hasAuthor={hasAuthor} />;
     }
 
     private renderAuthor(onlyAuthor: boolean) {
@@ -496,14 +498,14 @@ class DocPage extends React.Component<DocPageInnerProps, DocPageState> {
         );
     }
 
-    private renderContributors() {
+    private renderContributors(hasAuthor: boolean) {
         const {meta} = this.props;
 
         if (!meta?.contributors || meta.contributors.length === 0) {
             return null;
         }
 
-        return <Contributors users={meta.contributors} />;
+        return <Contributors users={meta.contributors} isAuthor={false} hasAuthor={hasAuthor} />;
     }
 
     private renderContentMiniToc() {

--- a/src/components/UpdatedAtDate/UpdatedAtDate.tsx
+++ b/src/components/UpdatedAtDate/UpdatedAtDate.tsx
@@ -11,9 +11,10 @@ const b = block('dc-updated-at-date');
 
 export interface UpdatedAtDateProps {
     updatedAt: string;
+    hasAuthor: boolean;
 }
 
-const UpdatedAtDate: React.FC<UpdatedAtDateProps> = ({updatedAt}) => {
+const UpdatedAtDate: React.FC<UpdatedAtDateProps> = ({updatedAt, hasAuthor}) => {
     const {t} = useTranslation('updated-at-date');
 
     const updatedAtFormatted = useMemo(() => {
@@ -21,10 +22,12 @@ const UpdatedAtDate: React.FC<UpdatedAtDateProps> = ({updatedAt}) => {
         return format(updatedAt, 'longDate', localeCode);
     }, [updatedAt]);
 
+    const titleKey = hasAuthor ? 'title' : 'no-author-title';
+
     return (
         <div className={b()}>
             <div className={b('wrapper')}>
-                {t('title')} {updatedAtFormatted}
+                {t(titleKey)} {updatedAtFormatted}
             </div>
         </div>
     );

--- a/src/i18n/ar.json
+++ b/src/i18n/ar.json
@@ -65,7 +65,8 @@
     "title": "من تأليف"
   },
   "contributors": {
-    "title": "من تنقيح"
+    "title": "مُحَسَّنة",
+    "no-author-title": "تم تحسين المقالة"
   },
   "feedback": {
     "like-text": "مفيد",
@@ -107,7 +108,6 @@
     "label_description-2": ".",
     "label_link-main": "العودة إلى الصفحة الرئيسية",
     "label_link-access": "طلب الوصول",
-
     "label_subtext": "إنها متاحة على:",
     "label_lang-ar": "العربية",
     "label_lang-bg": "البلغارية",
@@ -150,6 +150,10 @@
   "paginator": {
     "next": "الصفحة التالية",
     "prev": "الصفحة السابقة"
+  },
+  "updated-at-date": {
+    "title": "مُحْدَّثة",
+    "no-author-title": "تم تحديث المقالة"
   },
   "header": {
     "versions-select-placeholder": "الإصدارات"

--- a/src/i18n/bg.json
+++ b/src/i18n/bg.json
@@ -64,7 +64,8 @@
     "title": "Статията е създадена"
   },
   "contributors": {
-    "title": "подобрена"
+    "title": "подобрена",
+    "no-author-title": "Статията е подобрена"
   },
   "feedback": {
     "like-text": "Статията е полезна",
@@ -106,7 +107,6 @@
     "label_description-2": ".",
     "label_link-main": "Върнете се към началната страница",
     "label_link-access": "Поискайте достъп",
-
     "label_subtext": "Тя е достъпна на:",
     "label_lang-ar": "Арабски",
     "label_lang-bg": "Български",
@@ -149,6 +149,10 @@
   "paginator": {
     "next": "Следваща страница",
     "prev": "Предходна страница"
+  },
+  "updated-at-date": {
+    "title": "Обновена",
+    "no-author-title": "Статията е обновена"
   },
   "header": {
     "versions-select-placeholder": "Версии"

--- a/src/i18n/cs.json
+++ b/src/i18n/cs.json
@@ -65,7 +65,8 @@
     "title": "Napsal(a)"
   },
   "contributors": {
-    "title": "vylepšil(a)"
+    "title": "vylepšil(a)",
+    "no-author-title": "Článek byl vylepšen"
   },
   "feedback": {
     "like-text": "Užitečné",
@@ -107,7 +108,6 @@
     "label_description-2": ".",
     "label_link-main": "Zpět na hlavní stránku",
     "label_link-access": "Požádat o přístup",
-
     "label_subtext": "Je k dispozici v:",
     "label_lang-ar": "Arabština",
     "label_lang-bg": "Bulharština",
@@ -152,7 +152,8 @@
     "prev": "Předchozí stránka"
   },
   "updated-at-date": {
-    "title": "Aktualizováno na"
+    "title": "Aktualizováno na",
+    "no-author-title": "Stránka byla aktualizována"
   },
   "header": {
     "versions-select-placeholder": "Verze"

--- a/src/i18n/el.json
+++ b/src/i18n/el.json
@@ -65,7 +65,8 @@
     "title": "Το άρθρο δημιουργήθηκε"
   },
   "contributors": {
-    "title": "βελτιώθηκε"
+    "title": "βελτιώθηκε",
+    "no-author-title": "Το άρθρο βελτιώθηκε"
   },
   "feedback": {
     "like-text": "Το άρθρο είναι χρήσιμο",
@@ -107,7 +108,6 @@
     "label_description-2": ".",
     "label_link-main": "Επιστροφή στην αρχική σελίδα",
     "label_link-access": "Αίτημα πρόσβασης",
-
     "label_subtext": "Είναι διαθέσιμο σε:",
     "label_lang-ar": "Αραβικά",
     "label_lang-bg": "Βουλγαρικά",
@@ -150,6 +150,10 @@
   "paginator": {
     "next": "Επόμενη σελίδα",
     "prev": "Προηγούμενη σελίδα"
+  },
+  "updated-at-date": {
+    "title": "Ενημερώθηκε",
+    "no-author-title": "Το άρθρο ενημερώθηκε"
   },
   "header": {
     "versions-select-placeholder": "Εκδόσεις"

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -65,7 +65,8 @@
     "title": "Written by"
   },
   "contributors": {
-    "title": "Improved by"
+    "title": "Improved by",
+    "no-author-title": "Article has been improved"
   },
   "feedback": {
     "like-text": "Helpful",
@@ -107,7 +108,6 @@
     "label_description-2": ".",
     "label_link-main": "Back to main page",
     "label_link-access": "Request access",
-
     "label_subtext": "It's available in:",
     "label_lang-ar": "Arabic",
     "label_lang-bg": "Bulgarian",
@@ -152,7 +152,8 @@
     "prev": "Previous page"
   },
   "updated-at-date": {
-    "title": "Updated at"
+    "title": "Updated at",
+    "no-author-title": "Article last updated at"
   },
   "header": {
     "versions-select-placeholder": "Versions"

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -65,7 +65,8 @@
     "title": "Escrito por"
   },
   "contributors": {
-    "title": "mejorado por"
+    "title": "mejorado por",
+    "no-author-title": "El artículo ha sido mejorado"
   },
   "feedback": {
     "like-text": "Útil",
@@ -107,7 +108,6 @@
     "label_description-2": ".",
     "label_link-main": "Volver a la página principal",
     "label_link-access": "Solicitar acceso",
-
     "label_subtext": "Está disponible en:",
     "label_lang-ar": "Árabe",
     "label_lang-bg": "Búlgaro",
@@ -152,7 +152,8 @@
     "prev": "Página anterior"
   },
   "updated-at-date": {
-    "title": "Actualizado en"
+    "title": "Actualizado en",
+    "no-author-title": "El artículo ha sido actualizado"
   },
   "header": {
     "versions-select-placeholder": "Versiones"

--- a/src/i18n/et.json
+++ b/src/i18n/et.json
@@ -65,7 +65,8 @@
     "title": "Selle artikli on koostanud"
   },
   "contributors": {
-    "title": "parandatud"
+    "title": "parandatud",
+    "no-author-title": "Artikkel on parandatud"
   },
   "feedback": {
     "like-text": "Kasulik artikkel",
@@ -107,7 +108,6 @@
     "label_description-2": ".",
     "label_link-main": "Tagasi pealehele",
     "label_link-access": "Küsi juurdepääsu",
-
     "label_subtext": "See on saadaval:",
     "label_lang-ar": "Araabia",
     "label_lang-bg": "Bulgaaria",
@@ -150,6 +150,10 @@
   "paginator": {
     "next": "Järgmine lehekülg",
     "prev": "Eelmine lehekülg"
+  },
+  "updated-at-date": {
+    "title": "Uuendatud",
+    "no-author-title": "Artikkel on uuendatud"
   },
   "header": {
     "versions-select-placeholder": "Versioonid"

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -65,7 +65,8 @@
     "title": "Rédigé par"
   },
   "contributors": {
-    "title": "amélioré par"
+    "title": "amélioré par",
+    "no-author-title": "L'article a été amélioré"
   },
   "feedback": {
     "like-text": "Utile",
@@ -107,7 +108,6 @@
     "label_description-2": ".",
     "label_link-main": "Retour à la page principale",
     "label_link-access": "Demander l’accès",
-
     "label_subtext": "Elle est disponible en:",
     "label_lang-ar": "Arabe",
     "label_lang-bg": "Bulgare",
@@ -152,7 +152,8 @@
     "prev": "Page précédente"
   },
   "updated-at-date": {
-    "title": "Mis à jour à"
+    "title": "Mis à jour à",
+    "no-author-title": "L'article a été mis à jour"
   },
   "header": {
     "versions-select-placeholder": "Versions"

--- a/src/i18n/he.json
+++ b/src/i18n/he.json
@@ -65,7 +65,8 @@
     "title": "נכתב על ידי"
   },
   "contributors": {
-    "title": "שופר על ידי"
+    "title": "שופר על ידי",
+    "no-author-title": "המאמר שופר"
   },
   "feedback": {
     "like-text": "שימושי",
@@ -107,7 +108,6 @@
     "label_description-2": ".",
     "label_link-main": "חזרה לדף הראשי",
     "label_link-access": "בקשת גישה",
-
     "label_subtext": "היא זמינה ב:",
     "label_lang-ar": "ערבית",
     "label_lang-bg": "בולגרית",
@@ -150,6 +150,10 @@
   "paginator": {
     "next": "העמוד הבא",
     "prev": "העמוד הקודם"
+  },
+  "updated-at-date": {
+    "title": "עודכן ב",
+    "no-author-title": "המאמר עודכן"
   },
   "header": {
     "versions-select-placeholder": "גרסאות"

--- a/src/i18n/kk.json
+++ b/src/i18n/kk.json
@@ -65,7 +65,8 @@
     "title": "Мақала жасалды"
   },
   "contributors": {
-    "title": "жақсартылды"
+    "title": "жақсартылды",
+    "no-author-title": "Мақала жақсартылды"
   },
   "feedback": {
     "like-text": "Мақала пайдалы болды",
@@ -107,7 +108,6 @@
     "label_description-2": ".",
     "label_link-main": "Басты бетке оралу",
     "label_link-access": "Қолжетімділік сұрату",
-
     "label_subtext": "Қол жетімді:",
     "label_lang-ar": "Араб",
     "label_lang-bg": "Болгар",
@@ -150,6 +150,10 @@
   "paginator": {
     "next": "Келесі бет",
     "prev": "Алдыңғы бет"
+  },
+  "updated-at-date": {
+    "title": "Жаңартылды",
+    "no-author-title": "Мақала жаңартылды"
   },
   "header": {
     "versions-select-placeholder": "Нұсқалар"

--- a/src/i18n/pt.json
+++ b/src/i18n/pt.json
@@ -65,7 +65,8 @@
     "title": "Artigo criado por"
   },
   "contributors": {
-    "title": "está melhor"
+    "title": "Melhorado por",
+    "no-author-title": "O artigo foi melhorado"
   },
   "feedback": {
     "like-text": "Este artigo foi útil",
@@ -107,7 +108,6 @@
     "label_description-2": ".",
     "label_link-main": "Voltar para a página inicial",
     "label_link-access": "Pedir acesso",
-
     "label_subtext": "Está disponível em:",
     "label_lang-ar": "Árabe",
     "label_lang-bg": "Búlgaro",
@@ -150,6 +150,10 @@
   "paginator": {
     "next": "Página seguinte",
     "prev": "Página anterior"
+  },
+  "updated-at-date": {
+    "title": "Atualizado em",
+    "no-author-title": "O artigo foi atualizado"
   },
   "header": {
     "versions-select-placeholder": "Versões"

--- a/src/i18n/ru.json
+++ b/src/i18n/ru.json
@@ -65,7 +65,8 @@
     "title": "Статья создана"
   },
   "contributors": {
-    "title": "Улучшена"
+    "title": "Улучшена",
+    "no-author-title": "Статья улучшена"
   },
   "feedback": {
     "like-text": "Статья полезна",
@@ -152,7 +153,8 @@
     "prev": "Предыдущая страница"
   },
   "updated-at-date": {
-    "title": "Обновлена"
+    "title": "Обновлена",
+    "no-author-title": "Статья обновлена"
   },
   "header": {
     "versions-select-placeholder": "Версии"

--- a/src/i18n/tr.json
+++ b/src/i18n/tr.json
@@ -65,7 +65,8 @@
     "title": "Yazı oluşturuldu"
   },
   "contributors": {
-    "title": "iyileştirildi"
+    "title": "iyileştirildi",
+    "no-author-title": "Makale iyileştirildi"
   },
   "feedback": {
     "like-text": "Yazı yararlı oldu",
@@ -107,7 +108,6 @@
     "label_description-2": ".",
     "label_link-main": "Ana sayfaya geri dön",
     "label_link-access": "Erişim iste",
-
     "label_subtext": "Şurada mevcut:",
     "label_lang-ar": "Arapça",
     "label_lang-bg": "Bulgarca",
@@ -150,6 +150,10 @@
   "paginator": {
     "next": "Sonraki sayfa",
     "prev": "Önceki sayfa"
+  },
+  "updated-at-date": {
+    "title": "güncellendi",
+    "no-author-title": "Makale güncellendi"
   },
   "header": {
     "versions-select-placeholder": "Sürümler"

--- a/src/i18n/uz.json
+++ b/src/i18n/uz.json
@@ -65,7 +65,8 @@
     "title": "Maqola yaratilgan sana"
   },
   "contributors": {
-    "title": "yaxshilandi"
+    "title": "yaxshilandi",
+    "no-author-title": "Maqola yaxshilandi"
   },
   "feedback": {
     "like-text": "Maqola foyda berdi",
@@ -107,7 +108,6 @@
     "label_description-2": ".",
     "label_link-main": "Asosiyga qaytish",
     "label_link-access": "Kirishga ruxsat soʻrash",
-
     "label_subtext": "U mavjud:",
     "label_lang-ar": "Arab",
     "label_lang-bg": "Bolgarcha",
@@ -150,6 +150,10 @@
   "paginator": {
     "next": "Keyingi sahifa",
     "prev": "Avvalgi sahifa"
+  },
+  "updated-at-date": {
+    "title": "yangilandi",
+    "no-author-title": "Maqola yangilandi"
   },
   "header": {
     "versions-select-placeholder": "Versiyalar"

--- a/src/i18n/zh-tw.json
+++ b/src/i18n/zh-tw.json
@@ -65,7 +65,8 @@
     "title": "文章已完成"
   },
   "contributors": {
-    "title": "已得到完善"
+    "title": "已得到完善",
+    "no-author-title": "文章已改善"
   },
   "feedback": {
     "like-text": "文章有所裨益",
@@ -107,7 +108,6 @@
     "label_description-2": "。",
     "label_link-main": "返回主頁",
     "label_link-access": "請求訪問權限",
-
     "label_subtext": "它可在以下語言使用：",
     "label_lang-ar": "阿拉伯語",
     "label_lang-bg": "保加利亞語",
@@ -150,6 +150,10 @@
   "paginator": {
     "next": "下一頁",
     "prev": "上一頁"
+  },
+  "updated-at-date": {
+    "title": "已更新",
+    "no-author-title": "文章已更新"
   },
   "header": {
     "versions-select-placeholder": "版本"

--- a/src/i18n/zh.json
+++ b/src/i18n/zh.json
@@ -65,7 +65,8 @@
     "title": "文章已完成"
   },
   "contributors": {
-    "title": "已得到完善"
+    "title": "已得到完善",
+    "no-author-title": "文章已改善"
   },
   "feedback": {
     "like-text": "文章有所裨益",
@@ -107,7 +108,6 @@
     "label_description-2": "。",
     "label_link-main": "返回主页",
     "label_link-access": "请求访问权限",
-
     "label_subtext": "可在以下语言使用：",
     "label_lang-ar": "阿拉伯语",
     "label_lang-bg": "保加利亚语",
@@ -150,6 +150,10 @@
   "paginator": {
     "next": "下一页",
     "prev": "上一页"
+  },
+  "updated-at-date": {
+    "title": "已更新",
+    "no-author-title": "文章已更新"
   },
   "header": {
     "versions-select-placeholder": "版本"


### PR DESCRIPTION
Added localization keys ('no-author-title') for article status updates in ru.json.
Added "Статья" to "Улучшена/Обновлена" to provide clarity when there is no author, as requested.
Updated components:
- Contributers
- UpdatedAtDate
- DocPage