### PR TITLE
fix: dc-breadcrumbs__item:after content

### DIFF
--- a/src/components/Breadcrumbs/Breadcrumbs.scss
+++ b/src/components/Breadcrumbs/Breadcrumbs.scss
@@ -20,7 +20,7 @@
         display: inline;
 
         &::after {
-            content: '\a0/ ';
+            content: '\a0/\a0';
             margin: 0 5px;
             color: var(--g-color-text-hint);
         }


### PR DESCRIPTION
Fixed a bug where the `Â` character was incorrectly displayed instead of a space. 
This was caused by an encoding issue with the `\a0` non-breaking space inside single quotes in CSS. 
Changed the breadcrumbs item separator pseudo-element (`&::after`) to use standard double quotes / safe spacing.