### PR TITLE
feat(subnavigation): Sidebar custom menu icons, style improvements

### DIFF
--- a/demo/src/Components/DocPage/index.stories.tsx
+++ b/demo/src/Components/DocPage/index.stories.tsx
@@ -1,5 +1,11 @@
 /* eslint-disable no-console */
-import type {AvailableLangs, FeedbackSendData, Lang, Theme} from '@diplodoc/components';
+import type {
+    AvailableLangs,
+    FeedbackSendData,
+    Lang,
+    RenderSidebarIcon,
+    Theme,
+} from '@diplodoc/components';
 
 import {join} from 'path';
 import React, {useCallback, useEffect, useState} from 'react';
@@ -12,7 +18,7 @@ import {
 } from '@diplodoc/components';
 import {Button, Icon, configure as configureUikit, spacing} from '@gravity-ui/uikit';
 import cn from 'bem-cn-lite';
-import {SquareListUl} from '@gravity-ui/icons';
+import {Dots9, SquareListUl, Xmark} from '@gravity-ui/icons';
 
 import {updateBodyClassName} from '../utils';
 
@@ -40,6 +46,9 @@ const beforeSubNavigationContent = (
         Action button
     </Button>
 );
+
+const renderSidebarIcon: RenderSidebarIcon = ({isSidebarOpened}) =>
+    isSidebarOpened ? <Xmark width={20} height={20} /> : <Dots9 width={20} height={20} />;
 
 const useSettings = () => {
     const [wideFormat, onChangeWideFormat] = useState(DEFAULT_SETTINGS.wideFormat);
@@ -317,7 +326,8 @@ const DocPageDemo = (
                 hideTocHeader={hideTocHeader}
                 hideFeedback={hideFeedback}
                 availableLangs={availableLangs}
-                beforeSubNavigationContent={beforeSubNavigationContent}
+                beforeSubNavigationContent={mobileView ? undefined : beforeSubNavigationContent}
+                renderSidebarIcon={renderSidebarIcon}
                 // TODO: return highlight examples
                 // onContentMutation={onContentMutation}
                 // onContentLoaded={onContentLoaded}

--- a/src/components/DocLayout/DocLayout.scss
+++ b/src/components/DocLayout/DocLayout.scss
@@ -87,7 +87,7 @@
 
         &__right {
             position: sticky;
-            top: calc(var(--dc-header-height, #{variables.$headerHeight}) - 1px);
+            top: calc(var(--dc-header-height, #{variables.$headerHeight}));
             left: 0;
             z-index: 118;
 

--- a/src/components/DocPage/DocPage.tsx
+++ b/src/components/DocPage/DocPage.tsx
@@ -14,6 +14,7 @@ import type {
 } from '../../models';
 import type {InnerProps} from '../../utils';
 import type {NotificationProps} from '../Notification';
+import type {RenderSidebarIcon} from '../navigation';
 
 import React from 'react';
 import {Link} from '@gravity-ui/icons';
@@ -94,6 +95,7 @@ export interface DocPageProps extends DocPageData, DocSettings, NotificationProp
     viewerInterface?: Record<string, boolean>;
     availableLangs?: AvailableLangs;
     beforeSubNavigationContent?: React.ReactNode;
+    renderSidebarIcon?: RenderSidebarIcon;
 }
 
 type DocPageInnerProps = InnerProps<DocPageProps, DocSettings>;
@@ -176,6 +178,7 @@ class DocPage extends React.Component<DocPageInnerProps, DocPageState> {
             notificationCb,
             availableLangs = [],
             beforeSubNavigationContent,
+            renderSidebarIcon,
         } = this.props;
 
         const hideBurger = typeof headerHeight !== 'undefined' && headerHeight > 0;
@@ -259,6 +262,7 @@ class DocPage extends React.Component<DocPageInnerProps, DocPageState> {
                             onMiniTocItemClick={
                                 onMiniTocItemClick as unknown as (event: React.MouseEvent) => void
                             }
+                            renderSidebarIcon={renderSidebarIcon}
                         />
                     </div>
                 </DocLayout.Right>

--- a/src/components/MobileControls/MobileControls.scss
+++ b/src/components/MobileControls/MobileControls.scss
@@ -9,13 +9,13 @@
     align-items: center;
     justify-content: space-between;
 
-    height: 44px;
+    height: #{variables.$mobileControlsHeight};
 
     width: calc(100% - 2 * #{$padding-inline});
 
     box-sizing: content-box;
-    padding-top: 4px;
-    padding-bottom: 34px;
+    padding-top: #{variables.$mobileControlsTopPadding};
+    padding-bottom: #{variables.$mobileControlsBottomPadding};
     padding-inline: $padding-inline;
 
     background-color: var(--g-color-base-background);

--- a/src/components/SubNavigation/SubNavigation.scss
+++ b/src/components/SubNavigation/SubNavigation.scss
@@ -11,6 +11,7 @@
 
     display: flex;
     justify-content: space-between;
+    align-items: center;
 
     box-sizing: content-box;
     width: calc(100% - 2 * #{$horizontalPadding});
@@ -85,7 +86,19 @@
         justify-content: center;
         align-items: center;
 
-        padding: 12px;
+        padding: var(--g-spacing-2, 8px) var(--g-spacing-3, 12px);
+    }
+
+    &__arrow {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        padding: 0 var(--g-spacing-3, 12px);
+        transition: transform 0.15s;
+
+        .dc-subnavigation__mini-toc-button_active & {
+            transform: rotate(180deg);
+        }
     }
 
     &__mini-toc-button {
@@ -104,9 +117,8 @@
         padding-left: 4px;
         gap: $gap;
 
-        border-radius: var(--g-border-radius-xs, 3px);
+        border-radius: var(--g-border-radius-xl, 10px);
         border: none;
-        border-left: 1px solid var(--g-color-line-generic);
         outline: none;
 
         color: var(--g-color-text-primary);
@@ -139,6 +151,13 @@
 
         &_disabled {
             user-select: text;
+        }
+
+        &_active {
+            &:not(&_disabled) {
+                color: var(--g-color-text-primary);
+                background-color: var(--g-color-base-generic);
+            }
         }
 
         &_label {
@@ -186,13 +205,12 @@
         white-space: nowrap;
         overflow: hidden;
         text-overflow: ellipsis;
-
-        &_single {
-            padding-left: $horizontalPadding;
-        }
+        flex: 1 0 0;
     }
 
     & &__share-button {
+        margin: 0;
+
         &_absolute {
             position: absolute;
             right: 0;

--- a/src/components/SubNavigation/SubNavigation.tsx
+++ b/src/components/SubNavigation/SubNavigation.tsx
@@ -1,9 +1,10 @@
 import type {MouseEvent} from 'react';
 import type {DocHeadingItem, Router, TocData} from '../../models';
 import type {MobileControlsProps} from '../MobileControls';
+import type {RenderSidebarIcon} from '../navigation';
 
 import React, {memo, useCallback, useRef, useState} from 'react';
-import {SquareListUl} from '@gravity-ui/icons';
+import {ChevronDown, SquareListUl} from '@gravity-ui/icons';
 import block from 'bem-cn-lite';
 
 import {useInterface} from '../../hooks/useInterface';
@@ -24,6 +25,11 @@ const ICON_SIZE = {
     height: 20,
 };
 
+const ARROW_SIZE = {
+    width: 16,
+    height: 16,
+};
+
 export interface SubNavigationProps {
     router: Router;
     toc: TocData;
@@ -37,6 +43,7 @@ export interface SubNavigationProps {
     hideTocHeader?: boolean;
     tocTitleIcon?: React.ReactNode;
     onMiniTocItemClick?: (event: MouseEvent) => void;
+    renderSidebarIcon?: RenderSidebarIcon;
 }
 
 const SubNavigation = memo(
@@ -53,6 +60,7 @@ const SubNavigation = memo(
         hideTocHeader,
         tocTitleIcon,
         onMiniTocItemClick,
+        renderSidebarIcon,
     }: SubNavigationProps) => {
         const ref = useRef<HTMLDivElement>(null);
         const isTocHidden = useInterface('toc');
@@ -89,6 +97,7 @@ const SubNavigation = memo(
                 isSidebarOpened={menuOpen}
                 onSidebarOpenedChange={onSidebarOpenedChange}
                 mobileControlsData={mobileControlsData}
+                renderSidebarIcon={renderSidebarIcon}
             >
                 {!isTocHidden && (
                     <div className={b('toc')}>
@@ -106,8 +115,8 @@ const SubNavigation = memo(
 
         const shareButton = (
             <ShareButton
-                size={'xl'}
-                view={'flat'}
+                size="xl"
+                view="flat"
                 iconSize={ICON_SIZE}
                 className={b('share-button', {
                     invisible: menuOpen && hideBurger,
@@ -120,6 +129,7 @@ const SubNavigation = memo(
             <button
                 className={b('mini-toc-button', {
                     disabled: menuOpen || hideMiniToc,
+                    active: miniTocOpen,
                 })}
                 type={'button'}
                 disabled={menuOpen || hideMiniToc}
@@ -130,9 +140,12 @@ const SubNavigation = memo(
                         <SquareListUl {...ICON_SIZE} />
                     </div>
                 )}
-                <span className={b('title', {single: true})}>
-                    {activeHeading?.title ?? pageTitle}
-                </span>
+                <span className={b('title')}>{activeHeading?.title ?? pageTitle}</span>
+                {!hideMiniToc && (
+                    <div className={b('arrow')}>
+                        <ChevronDown {...ARROW_SIZE} />
+                    </div>
+                )}
             </button>
         );
 

--- a/src/components/Toc/Toc.scss
+++ b/src/components/Toc/Toc.scss
@@ -25,6 +25,12 @@ $leftOffset: 57px;
 
         border-right: none;
         overflow-y: auto;
+        height: calc(
+            100vh - var(--dc-header-height, #{variables.$headerHeight}) -
+                #{variables.$subNavigationHeight} - 1px - #{variables.$mobileControlsHeight} -
+                #{variables.$mobileControlsTopPadding} - #{variables.$mobileControlsBottomPadding} -
+                1px
+        );
     }
 
     &__empty {

--- a/src/components/navigation/Sidebar/Sidebar.scss
+++ b/src/components/navigation/Sidebar/Sidebar.scss
@@ -6,10 +6,16 @@
     $transitionTime: 0.4s;
 
     position: fixed;
-    top: var(--dc-header-height, #{variables.$headerHeight});
+    top: calc(
+        var(--dc-header-height, #{variables.$headerHeight}) + #{variables.$subNavigationHeight} +
+            1px
+    );
     z-index: 119;
 
-    height: calc(100% - var(--dc-header-height, #{variables.$headerHeight}) + 1px);
+    height: calc(
+        100% - var(--dc-header-height, #{variables.$headerHeight}) -
+            #{variables.$subNavigationHeight} + 1px
+    );
     width: 100vw;
 
     background-color: var(--g-color-base-background, #fff);

--- a/src/components/navigation/SidebarNavigation/SidebarNavigation.scss
+++ b/src/components/navigation/SidebarNavigation/SidebarNavigation.scss
@@ -5,8 +5,21 @@
     $itemPadding: 24px;
 
     &__button {
-        margin-right: 14px;
         user-select: none;
+
+        &_active {
+            color: var(--g-color-text-primary);
+
+            &::before {
+                background-color: var(--g-color-base-generic);
+            }
+
+            &:hover {
+                &::before {
+                    background-color: var(--g-color-base-generic);
+                }
+            }
+        }
     }
 
     &__navigation {

--- a/src/components/navigation/SidebarNavigation/SidebarNavigation.tsx
+++ b/src/components/navigation/SidebarNavigation/SidebarNavigation.tsx
@@ -14,16 +14,29 @@ import './SidebarNavigation.scss';
 
 const b = block('dc-sidebar-navigation');
 
+const ICON_SIZE = {
+    width: 20,
+    height: 20,
+};
+
+export interface RenderSidebarIconProps {
+    isSidebarOpened: boolean;
+}
+
+export type RenderSidebarIcon = (props: RenderSidebarIconProps) => React.ReactNode;
+
 export interface SidebarNavigationProps extends ClassNameProps {
     isSidebarOpened: boolean;
     onSidebarOpenedChange: (isOpened: boolean) => void;
     mobileControlsData?: MobileControlsProps;
+    renderSidebarIcon?: RenderSidebarIcon;
 }
 
 const SidebarNavigation: React.FC<SidebarNavigationProps & PropsWithChildren> = ({
     isSidebarOpened,
     onSidebarOpenedChange,
     mobileControlsData,
+    renderSidebarIcon,
     children,
     className,
 }) => {
@@ -35,14 +48,21 @@ const SidebarNavigation: React.FC<SidebarNavigationProps & PropsWithChildren> = 
         [isSidebarOpened, onSidebarOpenedChange],
     );
 
+    const SidebarIcon = isSidebarOpened ? Xmark : Bars;
+
     return (
         <div className={b()}>
-            <Button className={b('button', className)} onClick={toggle} view={'flat'} size="xl">
+            <Button
+                className={b('button', {active: isSidebarOpened}, className)}
+                onClick={toggle}
+                view={'flat'}
+                size="xl"
+            >
                 <Button.Icon>
-                    {isSidebarOpened ? (
-                        <Xmark width={20} height={20} />
+                    {renderSidebarIcon ? (
+                        renderSidebarIcon({isSidebarOpened})
                     ) : (
-                        <Bars width={20} height={20} />
+                        <SidebarIcon {...ICON_SIZE} />
                     )}
                 </Button.Icon>
             </Button>

--- a/src/styles/variables.scss
+++ b/src/styles/variables.scss
@@ -25,6 +25,11 @@ $miniTocTitleHeight: 20px; // line-height body-2
 $miniTocTitleMargin: 12px;
 $mobileMiniTocOffset: 2 * $miniTocVerticalPadding + $miniTocTitleHeight + $miniTocTitleMargin;
 
+// MobileControls
+$mobileControlsHeight: 44px;
+$mobileControlsTopPadding: 4px;
+$mobileControlsBottomPadding: 34px;
+
 $screenBreakpoints: (
     'xs': 375px,
     'sm': 577px,


### PR DESCRIPTION
- custom mobile sidebar open/close menu icon
- style improvements for mobile subnavigation row and mobile sidebar 

Before:
<img width="412" height="905" alt="Screenshot 2026-06-10 at 14 12 30" src="https://github.com/user-attachments/assets/c0bc78a3-2c77-43e6-ab8a-f8de47c5da86" />

After:
<img width="413" height="910" alt="Screenshot 2026-06-10 at 14 12 13" src="https://github.com/user-attachments/assets/1535e391-a042-4d31-baa3-abdf239ef672" />
