### PR TITLE
Add background images to gallery filter

### DIFF
--- a/src/components/Gallery/utils.tsx
+++ b/src/components/Gallery/utils.tsx
@@ -15,6 +15,8 @@ export type GetGalleryItemVideoArgs = {
 export const isExcludedByParent = (el: HTMLElement): boolean => {
     if (el.closest('.dc-contributor-avatars__avatar')) return true;
 
+    if (el.closest('[class*="background"]')) return true;
+
     return Boolean(
         el.closest(
             '[class^="icon"], [class*=" icon"], [class*="-icon"], [class*="_icon"], [class*="Icon"]',


### PR DESCRIPTION
Added background image filtering to prevent decorative layouts from leaking into the media gallery.
Updated isexcludedByParent helper to detect and skip elements containing "background" in class names.