### PR TITLE
Add enableDataStaffLogin props to Contributor

### DIFF
--- a/demo/src/Components/ContributorAvatars/index.stories.tsx
+++ b/demo/src/Components/ContributorAvatars/index.stories.tsx
@@ -1,0 +1,75 @@
+import type {Contributor} from '@diplodoc/components';
+
+import React from 'react';
+import {ContributorAvatars as Component} from '@diplodoc/components';
+
+const ContributorAvatarsDemo = (args: Record<string, any>) => {
+    const currentEnable = args['EnableDataStaffLogin'];
+    const showMultiple = args['ShowMultiple'];
+
+    const mockUsers: Contributor[] = showMultiple
+        ? [
+              {
+                  avatar: 'https://githubusercontent.com',
+                  email: 'robot-dataui-vcs@yandex-team.ru',
+                  login: 'robot-dataui-vcs-login',
+                  name: 'DataUI VCS Robot',
+                  url: 'http://yandex.ru',
+                  enableDataStaffLogin: currentEnable,
+              },
+              {
+                  avatar: 'https://githubusercontent.com',
+                  email: 'skanunnikov@yandex-team.ru',
+                  login: 'skanunnikov',
+                  name: 'Sergey Kanunnikov',
+                  url: '',
+                  enableDataStaffLogin: currentEnable,
+              },
+          ]
+        : [
+              {
+                  avatar: 'https://githubusercontent.com',
+                  email: 'robot-dataui-vcs@yandex-team.ru',
+                  login: 'robot-dataui-vcs-login',
+                  name: 'DataUI VCS Robot',
+                  url: 'http://yandex.ru',
+                  enableDataStaffLogin: currentEnable,
+              },
+          ];
+
+    return (
+        <Component
+            contributors={mockUsers}
+            isAuthor={args['IsAuthor']}
+            onlyAuthor={args['OnlyAuthor']}
+        />
+    );
+};
+
+export default {
+    title: 'Components/ContributorAvatars',
+    component: ContributorAvatarsDemo,
+    argTypes: {
+        EnableDataStaffLogin: {
+            control: 'boolean',
+        },
+        ShowMultiple: {
+            control: 'boolean',
+        },
+        IsAuthor: {
+            control: 'boolean',
+        },
+        OnlyAuthor: {
+            control: 'boolean',
+        },
+    },
+};
+
+export const ContributorAvatars = {
+    args: {
+        EnableDataStaffLogin: true,
+        ShowMultiple: false,
+        IsAuthor: true,
+        OnlyAuthor: true,
+    },
+};

--- a/src/components/ContributorAvatars/ContributorAvatars.tsx
+++ b/src/components/ContributorAvatars/ContributorAvatars.tsx
@@ -44,6 +44,7 @@ const ContributorAvatars: React.FC<ContributorAvatarsProps> = (props) => {
                 key={`displayed-contributors-${login || email}`}
                 href={url}
                 extraProps={{tabIndex: contributor.avatar ? undefined : -1}} // as Avatar component may be button
+                {...(contributor.enableDataStaffLogin && login ? {'data-staff': login} : {})}
             >
                 <AvatarWithDescription contributor={contributor} avatarSize={AvatarSizes.SMALL} />
             </Link>
@@ -75,12 +76,18 @@ function getOneAvatar(
     };
 
     const wrapperModifiers = isAuthor ? {onlyAuthor} : {};
-
+    const enableStaffLogin = contributor.enableDataStaffLogin
+        ? {['data-staff']: contributor.login}
+        : {};
     return (
         <div className={b('one_contributor', wrapperModifiers)}>
             {getRedirectingAvatar(avatarData, contributor.url)}
             <div>
-                <Link href={contributor.url}>{getName(contributor, isAuthor)}</Link>
+                <Link href={contributor.url} {...enableStaffLogin}>
+                    {contributor.enableDataStaffLogin
+                        ? contributor.login
+                        : getName(contributor, isAuthor)}
+                </Link>
             </div>
         </div>
     );
@@ -88,8 +95,15 @@ function getOneAvatar(
 
 function getRedirectingAvatar(avatarData: AvatarData, url: string, isRedirect = false) {
     // as Avatar component may be a button, one need to set tabIndex
+    const enableStaffLogin = avatarData.contributor.enableDataStaffLogin
+        ? {['data-staff']: avatarData.contributor.login}
+        : {};
     return (
-        <Link href={url} extraProps={{tabIndex: avatarData.contributor.avatar ? undefined : -1}}>
+        <Link
+            href={url}
+            extraProps={{tabIndex: avatarData.contributor.avatar ? undefined : -1}}
+            {...enableStaffLogin}
+        >
             <Avatar avatarData={avatarData} isRedirect={isRedirect} />
         </Link>
     );

--- a/src/components/ContributorAvatars/__tests__/ContributorAvatars.spec.ts
+++ b/src/components/ContributorAvatars/__tests__/ContributorAvatars.spec.ts
@@ -1,5 +1,6 @@
 import {expect, test} from '@playwright/test';
 
+import {CONTRIBUTOR_AVATARS_URL} from 'src/components/constants';
 import {loadDocumentPage} from 'src/components/utils';
 
 test.beforeEach(async ({page}) => {
@@ -39,6 +40,18 @@ test('ContributorAvatars test', async ({page}) => {
     await hiddenAvatars.click();
     await expect(page).toHaveScreenshot('HiddenAvatars-popup.png', {
         clip,
+        maxDiffPixelRatio: 0.02,
+    });
+});
+
+test('ContributorAvatars story should render data-staff attribute', async ({page}) => {
+    await loadDocumentPage(page, CONTRIBUTOR_AVATARS_URL);
+
+    const author = page.locator('.dc-contributor-avatars__one_contributor a').nth(0);
+
+    await expect(author).toHaveAttribute('data-staff', 'robot-dataui-vcs-login');
+
+    await expect(page).toHaveScreenshot('ContributorAvatars-InternalStaff.png', {
         maxDiffPixelRatio: 0.02,
     });
 });

--- a/src/components/constants.ts
+++ b/src/components/constants.ts
@@ -23,3 +23,5 @@ export const ERROR_PAGE_URL =
     '/iframe.html?args=ErrorCode:403;Title:Page%20403;ReceiveAccessText:Custom%20link;ReceiveAccessUrl:access&id=pages-error--error&viewMode=story';
 export const SEARCH_SUGGEST_WITH_AI_URL =
     BASE_URL + '/iframe.html?id=pages-searchsuggestwithai--search-suggest-with-ai&viewMode=story';
+export const CONTRIBUTOR_AVATARS_URL =
+    BASE_URL + '/iframe.html?id=components-contributoravatars--contributor-avatars&viewMode=story';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,7 @@
 export * from './components/Breadcrumbs';
 export * from './components/ConsentPopup';
+export * from './components/ContributorAvatars';
+export * from './components/Contributors';
 export * from './components/DocLayout';
 export * from './components/DocLeadingPage';
 export * from './components/DocPage';

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -196,6 +196,7 @@ export interface Contributor {
     url: string;
     name: string | null;
     email: string | null;
+    enableDataStaffLogin: boolean;
 }
 
 export interface DislikeData {


### PR DESCRIPTION
## Description
Added enableDataStaffLogin props to Contributor
- If enableDataStaffLogin = true, components will render the contributor's login and append the data-staff attribute.
- In the default case (external docs), it falls back to rendering the `email`/`name` without extra attributes.
