### PR TITLE
Add cursor pointer for gallery images

### DIFF
--- a/src/components/Gallery/Gallery.scss
+++ b/src/components/Gallery/Gallery.scss
@@ -3,3 +3,7 @@
     height: 100%;
     border: none;
 }
+
+.dc-gallery__media-clickable {
+    cursor: pointer;
+}

--- a/src/components/Gallery/hooks/useGalleryOpen.ts
+++ b/src/components/Gallery/hooks/useGalleryOpen.ts
@@ -10,6 +10,15 @@ export interface UseGalleryOpenProps {
 export function useGalleryOpen({contentSelector}: UseGalleryOpenProps) {
     const {openGallery} = useGallery();
 
+    useEffect(() => {
+        const container = document.querySelector(contentSelector);
+        if (!container) return;
+
+        Array.from(container.querySelectorAll<HTMLElement>('img'))
+            .filter((el) => isMediaElement(el) && !el.closest('a'))
+            .forEach((el) => el.classList.add('dc-gallery__media-clickable'));
+    }, [contentSelector]);
+
     const handleGlobalClick = useCallback(
         (event: MouseEvent) => {
             const target = event.target as HTMLElement;


### PR DESCRIPTION
## Description
Add `dc-gallery__media-clickable` CSS class to images that are eligible for the gallery (visible, not inside a link, not icons or avatars). 