### PR TITLE
chore(ci): add per-PR Storybook preview link

### DIFF
--- a/.github/workflows/pr-storybook-report.yml
+++ b/.github/workflows/pr-storybook-report.yml
@@ -1,0 +1,43 @@
+name: PR Storybook Preview Report
+
+on:
+  workflow_run:
+    workflows: ['PR Storybook Preview']
+    types:
+      - completed
+
+jobs:
+  comment:
+    name: Create GitHub Comment
+    if: github.event.workflow_run.event == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download Artifacts
+        uses: actions/download-artifact@v4
+        with:
+          github-token: ${{ secrets.YC_UI_BOT_GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
+      - name: Extract PR Number
+        id: pr
+        run: echo "::set-output name=id::$(<pr/pr-id.txt)"
+        shell: bash
+      - name: Install AWS CLI
+        uses: unfor19/install-aws-cli-action@v1
+        with:
+          version: 2.22.35
+          arch: amd64
+      - name: Upload to S3
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.S3_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: ru-central1
+          AWS_EC2_METADATA_DISABLED: true
+        run: aws s3 cp storybook-static s3://diplodoc-playwright-reports/components/${{ steps.pr.outputs.id }}/storybook/ --endpoint-url=https://storage.yandexcloud.net --recursive
+        shell: bash
+      - name: Create Comment
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          GITHUB_TOKEN: ${{ secrets.YC_UI_BOT_GITHUB_TOKEN }}
+          number: ${{ steps.pr.outputs.id }}
+          header: storybook preview
+          message: '[Storybook preview](https://storage.yandexcloud.net/diplodoc-playwright-reports/components/${{ steps.pr.outputs.id }}/storybook/index.html) is ready.'

--- a/.github/workflows/pr-storybook-report.yml
+++ b/.github/workflows/pr-storybook-report.yml
@@ -22,7 +22,7 @@ jobs:
         run: echo "::set-output name=id::$(<pr/pr-id.txt)"
         shell: bash
       - name: Install AWS CLI
-        uses: unfor19/install-aws-cli-action@v1
+        uses: unfor19/install-aws-cli-action@f5b46b7f32cf5e7ebd652656c5036bf83dd1e60c # v1
         with:
           version: 2.22.35
           arch: amd64
@@ -35,7 +35,7 @@ jobs:
         run: aws s3 cp storybook-static s3://diplodoc-playwright-reports/components/${{ steps.pr.outputs.id }}/storybook/ --endpoint-url=https://storage.yandexcloud.net --recursive
         shell: bash
       - name: Create Comment
-        uses: marocchino/sticky-pull-request-comment@v2
+        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2
         with:
           GITHUB_TOKEN: ${{ secrets.YC_UI_BOT_GITHUB_TOKEN }}
           number: ${{ steps.pr.outputs.id }}

--- a/.github/workflows/pr-storybook.yml
+++ b/.github/workflows/pr-storybook.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Setup Node.js and install dependencies
-        uses: diplodoc-platform/setup-node-action@v1
+        uses: diplodoc-platform/setup-node-action@00e5cddb6b6eb5f5bc02d371fa70ce645f8f5554 # v1
         with:
           node-version: ${{ vars.NODE_VERSION || '24' }}
       - name: Install Demo Packages

--- a/.github/workflows/pr-storybook.yml
+++ b/.github/workflows/pr-storybook.yml
@@ -1,0 +1,41 @@
+name: PR Storybook Preview
+
+on:
+  pull_request:
+    branches: [master]
+
+jobs:
+  build_storybook:
+    name: Build Storybook
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Node.js and install dependencies
+        uses: diplodoc-platform/setup-node-action@v1
+        with:
+          node-version: ${{ vars.NODE_VERSION || '24' }}
+      - name: Install Demo Packages
+        run: cd demo && npm i
+      - name: Build Files
+        run: npm run build
+      - name: Build Storybook
+        run: cd demo && npm run build-storybook
+      - name: Upload Storybook Static
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: storybook-static
+          path: ./demo/storybook-static
+          retention-days: 1
+      - name: Save PR ID
+        if: always()
+        run: |
+          pr="${{ github.event.pull_request.number }}"
+          echo $pr > ./pr-id.txt
+        shell: bash
+      - name: Create PR Artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr
+          path: ./pr-id.txt


### PR DESCRIPTION
## What

Adds a per-PR Storybook preview link, mirroring the existing visual-tests report bot.

## How

Two workflows:
- `pr-storybook.yml` (on `pull_request`): builds the Storybook static bundle (`demo/storybook-static`) and uploads it, plus the PR id, as artifacts.
- `pr-storybook-report.yml` (on `workflow_run` completion): downloads the artifact, uploads it to the shared S3 bucket under `components/<pr>/storybook/`, and posts a sticky PR comment linking the preview.

It reuses the same secrets and bucket as the visual-tests report bot. The Storybook bundle is placed under a `/storybook/` subpath so it does not collide with the Playwright report's `index.html`.

## Note

The `workflow_run` half uses the workflow file from the default branch, so the preview comment will only start appearing once this is merged to master (the same limitation as the existing visual-tests report bot). It cannot be fully exercised from this PR.
