### PR TITLE
fix: add svg images to gallery, cursor zoom-in, remove default alt

### DIFF
--- a/src/components/Gallery/Gallery.scss
+++ b/src/components/Gallery/Gallery.scss
@@ -3,7 +3,3 @@
     height: 100%;
     border: none;
 }
-
-.dc-gallery__media-clickable {
-    cursor: pointer;
-}

--- a/src/components/Gallery/hooks/useGalleryOpen.ts
+++ b/src/components/Gallery/hooks/useGalleryOpen.ts
@@ -10,27 +10,18 @@ export interface UseGalleryOpenProps {
 export function useGalleryOpen({contentSelector}: UseGalleryOpenProps) {
     const {openGallery} = useGallery();
 
-    useEffect(() => {
-        const container = document.querySelector(contentSelector);
-        if (!container) return;
-
-        Array.from(container.querySelectorAll<HTMLElement>('img'))
-            .filter((el) => isMediaElement(el) && !el.closest('a'))
-            .forEach((el) => el.classList.add('dc-gallery__media-clickable'));
-    }, [contentSelector]);
-
     const handleGlobalClick = useCallback(
         (event: MouseEvent) => {
             const target = event.target as HTMLElement;
 
-            const clickedMedia = target.closest<HTMLElement>('img');
+            const clickedMedia = target.closest<HTMLElement>('img, svg');
             if (!clickedMedia || !isMediaElement(clickedMedia) || clickedMedia.closest('a')) return;
 
             const container = clickedMedia.closest(contentSelector);
             if (!container) return;
 
             const allMedia = Array.from(
-                container.querySelectorAll<HTMLElement>('img, .embed-responsive'),
+                container.querySelectorAll<HTMLElement>('img, svg, .embed-responsive'),
             ).filter(isMediaElement);
 
             const clickedIndex = allMedia.indexOf(clickedMedia);

--- a/src/components/Gallery/utils.tsx
+++ b/src/components/Gallery/utils.tsx
@@ -5,24 +5,48 @@ import {
     getGalleryItemDownloadAction,
     getGalleryItemImage,
 } from '@gravity-ui/components';
-import {FilePreview, type FilePreviewProps} from '@gravity-ui/uikit';
+import {FilePreview} from '@gravity-ui/uikit';
+
+const MIN_CONTENT_SIZE = 24;
+
+const ICON_SELECTORS = [
+    '[class^="icon"]',
+    '[class*=" icon"]',
+    '[class*="-icon"]',
+    '[class*="_icon"]',
+    '[class*="Icon"]',
+];
+
+const INTERACTIVE_SELECTORS = [
+    'button',
+    'a[role="button"]',
+    '[role="button"]',
+    '[role="tab"]',
+    '[class*="button"]',
+    '[class*="dc-nav-toc-panel__link"]',
+];
+
+const MISC_EXCLUDED_SELECTORS = ['.dc-contributor-avatars__avatar', '[class*="background"]'];
+
+const EXCLUDED_PARENT_SELECTORS = [
+    ...ICON_SELECTORS,
+    ...INTERACTIVE_SELECTORS,
+    ...MISC_EXCLUDED_SELECTORS,
+].join(', ');
 
 export type GetGalleryItemVideoArgs = {
     index: number;
     iframeEl: HTMLIFrameElement | null;
 };
 
-export const isExcludedByParent = (el: HTMLElement): boolean => {
-    if (el.closest('.dc-contributor-avatars__avatar')) return true;
-
-    if (el.closest('[class*="background"]')) return true;
-
-    return Boolean(
-        el.closest(
-            '[class^="icon"], [class*=" icon"], [class*="-icon"], [class*="_icon"], [class*="Icon"]',
-        ),
-    );
+export type ImageSource = {
+    name: string;
+    src: string;
+    mimeType: string;
 };
+
+export const isExcludedByParent = (el: HTMLElement): boolean =>
+    Boolean(el.closest(EXCLUDED_PARENT_SELECTORS));
 
 export const isContentImage = (el: HTMLImageElement): boolean => {
     if (el.getAttribute('aria-hidden') === 'true') return false;
@@ -34,16 +58,65 @@ export const isContentImage = (el: HTMLImageElement): boolean => {
     return true;
 };
 
+export const isContentSize = (el: SVGSVGElement): boolean => {
+    const rect = el.getBoundingClientRect();
+    return rect.width > MIN_CONTENT_SIZE && rect.height > MIN_CONTENT_SIZE;
+};
+
+export const isImageElement = (el: HTMLElement): el is HTMLImageElement => {
+    return el.tagName?.toLowerCase() === 'img';
+};
+
+export const isSvgElement = (el: Element): el is SVGSVGElement => {
+    return el.tagName?.toLowerCase() === 'svg';
+};
+
 export const isMediaElement = (el: HTMLElement): boolean => {
     if (isExcludedByParent(el)) return false;
-    if (el instanceof HTMLImageElement) return isContentImage(el);
+    if (isImageElement(el)) return isContentImage(el);
+    if (isSvgElement(el)) return isContentSize(el);
+
     return true;
+};
+
+export const getImageMimeType = (src: string): string => {
+    const ext = src.split('.').pop()?.split(/[?#]/)[0]?.toLowerCase();
+
+    switch (ext) {
+        case 'svg':
+            return 'image/svg+xml';
+        case 'png':
+            return 'image/png';
+        case 'jpg':
+        case 'jpeg':
+            return 'image/jpeg';
+        case 'gif':
+            return 'image/gif';
+        case 'webp':
+            return 'image/webp';
+        default:
+            return 'application/octet-stream';
+    }
+};
+
+export const serializeInlineSvg = (svgEl: SVGSVGElement): string => {
+    const serializer = new XMLSerializer();
+    let svgString = serializer.serializeToString(svgEl);
+
+    if (!/xmlns="http:\/\/www\.w3\.org\/2000\/svg"/.test(svgString)) {
+        svgString = svgString.replace('<svg', '<svg xmlns="http://www.w3.org/2000/svg"');
+    }
+
+    const bytes = new TextEncoder().encode(svgString);
+    const binary = Array.from(bytes, (byte) => String.fromCodePoint(byte)).join('');
+
+    return `data:image/svg+xml;base64,${window.btoa(binary)}`;
 };
 
 export function getGalleryItemVideo({index, iframeEl}: GetGalleryItemVideoArgs): GalleryItemProps {
     const rawSrc = iframeEl?.getAttribute('src') ?? '';
     const src = rawSrc.replace(/&amp;/g, '&');
-    const name = iframeEl?.getAttribute('title') ?? `video-${index + 1}`;
+    const name = iframeEl?.getAttribute('title') ?? '';
     const url = src.startsWith('http') ? src : new URL(src, window.location.origin).href;
 
     return {
@@ -59,38 +132,53 @@ export function getGalleryItemVideo({index, iframeEl}: GetGalleryItemVideoArgs):
                 className="dc-gallery__iframe"
             />
         ),
-        thumbnail: (
-            <FilePreview view="compact" file={{name, type: 'video'} as FilePreviewProps['file']} />
-        ),
+        thumbnail: <FilePreview view="compact" file={new File([], name, {type: 'video'})} />,
         actions: [getGalleryItemCopyLinkAction({copyUrl: url})],
     } as GalleryItemProps;
 }
 
+export const getImageSource = (el: HTMLElement): ImageSource => {
+    if (isImageElement(el)) {
+        return {
+            name: el.alt || '',
+            src: el.src,
+            mimeType: getImageMimeType(el.src),
+        };
+    }
+
+    if (isSvgElement(el)) {
+        return {
+            name: el.getAttribute('aria-label') || el.querySelector('title')?.textContent || '',
+            src: serializeInlineSvg(el),
+            mimeType: 'image/svg+xml',
+        };
+    }
+
+    throw new Error('Unsupported gallery image element: expected <img> or inline <svg>');
+};
+
 export const buildGalleryItem = (el: HTMLElement, index: number): GalleryItemProps => {
-    if (el.classList.contains('embed-responsive')) {
+    const isVideo = el.classList.contains('embed-responsive');
+
+    if (isVideo) {
         return getGalleryItemVideo({
             index,
             iframeEl: el.querySelector('iframe'),
         });
     }
 
-    const imgEl = el as HTMLImageElement;
-    const src = imgEl.src;
-    const name = imgEl.alt || `image-${index + 1}`;
+    const {name, src, mimeType} = getImageSource(el);
+    const file = new File([], name, {type: mimeType});
     const url = src.startsWith('http') ? src : new URL(src, window.location.origin).href;
-
+    const actions = isImageElement(el)
+        ? [
+              getGalleryItemCopyLinkAction({copyUrl: url}),
+              getGalleryItemDownloadAction({downloadUrl: src}),
+          ]
+        : [getGalleryItemDownloadAction({downloadUrl: src})];
     return {
         ...getGalleryItemImage({name, src}),
-        thumbnail: (
-            <FilePreview
-                view="compact"
-                file={{name, type: 'image/png'} as FilePreviewProps['file']}
-                imageSrc={src}
-            />
-        ),
-        actions: [
-            getGalleryItemCopyLinkAction({copyUrl: url}),
-            getGalleryItemDownloadAction({downloadUrl: src}),
-        ],
+        thumbnail: <FilePreview view="compact" file={file} imageSrc={src} />,
+        actions,
     };
 };

--- a/src/styles/yfm.scss
+++ b/src/styles/yfm.scss
@@ -37,6 +37,28 @@
     @include yfm-dark-hc.gravity-colors-for-diplodoc-dark-hc();
 }
 
+.dc-doc-page {
+    &__main {
+        img,
+        svg {
+            &:not(a *) {
+                &:not(
+                    [class*='dc-contributor-avatars__avatar'] img,
+                    [class*='background'] img,
+                    [class*='icon' i] img,
+                    [class*='icon' i] svg,
+                    [class*='noreferrer'] svg,
+                    [class*='noopener'] svg,
+                    [class*='nav' i] svg,
+                    [class*='button' i] svg
+                ) {
+                    cursor: zoom-in;
+                }
+            }
+        }
+    }
+}
+
 .dc-doc-page .yfm {
     color: var(--yfm-color-text);
 


### PR DESCRIPTION
## Description
Added SVG support to the gallery (both img src="*.svg" and inline svg), improved filtering to exclude decorative images (alt="") and non-content UI elements (icons, buttons, nav), and updated the cursor to pointer for clickable media.