### PR TITLE
fix(toc): the toc does not highlight the title page #5510

### DIFF
--- a/playwright/playwright.config.ts
+++ b/playwright/playwright.config.ts
@@ -8,7 +8,7 @@ function pathFromRoot(p: string) {
 }
 
 export default defineConfig({
-    testDir: pathFromRoot('src/components'),
+    testDir: pathFromRoot('src'),
     updateSnapshots: process.env.UPDATE_SNAPSHOTS ? 'all' : 'missing',
     snapshotPathTemplate:
         '{testDir}/{testFilePath}/../../__screenshots__/{arg}-{projectName}-{platform}{ext}',

--- a/src/utils/__tests__/path.spec.ts
+++ b/src/utils/__tests__/path.spec.ts
@@ -1,0 +1,50 @@
+import {expect, test} from '@playwright/test';
+
+import {isActiveItem, isExternalHref, normalizeHash, normalizePath} from '../path';
+
+test.describe('normalizePath', () => {
+    test('normalizes the root path for the title page', () => {
+        expect(normalizePath('/')).toBe('./');
+    });
+
+    test('normalizes article paths', () => {
+        expect(normalizePath('/guide/page.html')).toBe('guide/page');
+        expect(normalizePath('/guide/index.html')).toBe('guide/');
+        expect(normalizePath('/guide/page.html?lang=en')).toBe('guide/page?lang=en');
+        expect(normalizePath('/guide/index?lang=en')).toBe('guide/?lang=en');
+    });
+});
+
+test('normalizes hashes', () => {
+    expect(normalizeHash('#section')).toBe('section');
+    expect(normalizeHash('section')).toBe('section');
+});
+
+test.describe('isActiveItem', () => {
+    test('matches the title page against its relative link', () => {
+        expect(isActiveItem({pathname: '/'}, './')).toBe(true);
+    });
+
+    test('matches equivalent article paths', () => {
+        expect(isActiveItem({pathname: '/guide/index.html'}, 'guide/')).toBe(true);
+    });
+
+    test('does not match different article paths', () => {
+        expect(isActiveItem({pathname: '/guide/one'}, 'guide/two')).toBe(false);
+    });
+
+    test('matches hashes in single-page mode', () => {
+        const router = {pathname: '/', hash: '#section'};
+
+        expect(isActiveItem(router, './#section', true)).toBe(true);
+        expect(isActiveItem(router, './#other', true)).toBe(false);
+    });
+});
+
+test('detects external links', () => {
+    expect(isExternalHref('http://example.com')).toBe(true);
+    expect(isExternalHref('https://example.com')).toBe(true);
+    expect(isExternalHref('//example.com')).toBe(true);
+    expect(isExternalHref('/guide')).toBe(false);
+    expect(isExternalHref('./guide')).toBe(false);
+});

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -33,6 +33,10 @@ export function normalizePath(path?: string | null) {
         return path;
     }
 
+    if (path === '/') {
+        return './';
+    }
+
     return path
         .replace(/^\//, '')
         .replace(/\.html(\?.*)?$/, '$1')

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -6,10 +6,7 @@ import type {
     DocLeadingPageData,
     DocPageData,
     ListItem,
-    Router,
 } from '../models';
-
-import {parse} from 'url';
 
 import {DocContentPage} from '../components/DocContentPage';
 import {DocLeadingPage} from '../components/DocLeadingPage';
@@ -28,39 +25,7 @@ export type ChangeHandler<S> = <K extends keyof S, V extends S[K]>(
     value?: V,
 ) => () => void;
 
-export function normalizePath(path?: string | null) {
-    if (!path) {
-        return path;
-    }
-
-    if (path === '/') {
-        return './';
-    }
-
-    return path
-        .replace(/^\//, '')
-        .replace(/\.html(\?.*)?$/, '$1')
-        .replace(/\/index(\?.*)?$/, '/$1');
-}
-
-export function normalizeHash(hash?: string | null) {
-    if (hash && hash.startsWith('#')) {
-        return hash.substring(1);
-    }
-    return hash;
-}
-
-export function isActiveItem(router: Router, href: string, singlePage?: boolean) {
-    if (singlePage) {
-        return normalizeHash(router.hash) === normalizeHash(parse(href).hash);
-    }
-
-    return normalizePath(router.pathname) === normalizePath(parse(href).pathname);
-}
-
-export function isExternalHref(href: string) {
-    return href.startsWith('http') || href.startsWith('//');
-}
+export {isActiveItem, isExternalHref, normalizeHash, normalizePath} from './path';
 
 export function getStateKey(
     showMiniToc: boolean | unknown,

--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -1,0 +1,37 @@
+import type {Router} from '../models';
+
+import {parse} from 'url';
+
+export function normalizePath(path?: string | null) {
+    if (!path) {
+        return path;
+    }
+
+    if (path === '/') {
+        return './';
+    }
+
+    return path
+        .replace(/^\//, '')
+        .replace(/\.html(\?.*)?$/, '$1')
+        .replace(/\/index(\?.*)?$/, '/$1');
+}
+
+export function normalizeHash(hash?: string | null) {
+    if (hash?.startsWith('#')) {
+        return hash.substring(1);
+    }
+    return hash;
+}
+
+export function isActiveItem(router: Router, href: string, singlePage?: boolean) {
+    if (singlePage) {
+        return normalizeHash(router.hash) === normalizeHash(parse(href).hash);
+    }
+
+    return normalizePath(router.pathname) === normalizePath(parse(href).pathname);
+}
+
+export function isExternalHref(href: string) {
+    return href.startsWith('http') || href.startsWith('//');
+}


### PR DESCRIPTION
## Description
In normalizePath(), the root path / has been converted to ./. As a result, isActiveItem() correctly matches the current main page with the root TOC link and highlights the title page.

Related issue: #5510
