### PR TITLE
fix: add pointover to gallery images

### DIFF
--- a/src/components/Gallery/Gallery.tsx
+++ b/src/components/Gallery/Gallery.tsx
@@ -1,9 +1,9 @@
-import React, {useLayoutEffect} from 'react';
+import React, {useEffect} from 'react';
 import {GalleryProvider} from '@gravity-ui/components';
 
 import {useInterface} from '../../hooks/useInterface';
 
-import {applyGalleryCursors} from './utils';
+import {isMediaElement} from './utils';
 import {useGalleryOpen} from './hooks/useGalleryOpen';
 import './Gallery.scss';
 
@@ -12,29 +12,31 @@ export interface GalleryProps {
 }
 
 const GalleryCore: React.FC<{contentSelector: string}> = ({contentSelector}) => {
+    useEffect(() => {
+        const handlePointerOver = (event: PointerEvent) => {
+            if (!(event.target instanceof Element)) return;
+
+            const media = event.target.closest<HTMLElement>('img, svg');
+            if (!media || !media.closest(contentSelector)) return;
+
+            const isZoomable = isMediaElement(media) && !media.closest('a');
+
+            media.classList.toggle('dc-gallery__item', isZoomable);
+        };
+
+        document.addEventListener('pointerover', handlePointerOver, true);
+
+        return () => {
+            document.removeEventListener('pointerover', handlePointerOver, true);
+        };
+    }, [contentSelector]);
+
     useGalleryOpen({contentSelector});
     return null;
 };
 
 export const Gallery: React.FC<GalleryProps> = ({contentSelector = '.dc-doc-page__main'}) => {
     const isGalleryHidden = useInterface('gallery');
-
-    useLayoutEffect(() => {
-        const container = document.querySelector<HTMLElement>(contentSelector);
-        if (!container) return;
-        applyGalleryCursors(container);
-
-        const images = container.querySelectorAll<HTMLImageElement>('img, svg');
-        const handleLoad = () => applyGalleryCursors(container);
-        images.forEach((img) => {
-            if (img instanceof HTMLImageElement && !img.complete) {
-                img.addEventListener('load', handleLoad, {once: true});
-            }
-        });
-        return () => {
-            images.forEach((img) => img.removeEventListener('load', handleLoad));
-        };
-    }, [contentSelector]);
 
     if (isGalleryHidden) return null;
 

--- a/src/components/Gallery/utils.tsx
+++ b/src/components/Gallery/utils.tsx
@@ -17,7 +17,6 @@ const INTERACTIVE_SELECTORS = [
 
 const MISC_EXCLUDED_SELECTORS = ['.dc-contributor-avatars__avatar', '[class*="background"]'];
 const EXCLUDED_PARENT_SELECTORS = [...INTERACTIVE_SELECTORS, ...MISC_EXCLUDED_SELECTORS].join(', ');
-const GALLERY_ITEM_CLASS = 'dc-gallery__item';
 
 export type GetGalleryItemVideoArgs = {
     index: number;
@@ -57,17 +56,6 @@ export const isMediaElement = (el: HTMLElement): boolean => {
 
     return isContentSize(el);
 };
-
-export function applyGalleryCursors(container: HTMLElement): void {
-    const media = container.querySelectorAll<HTMLElement>('img, svg');
-
-    media.forEach((el) => {
-        const isZoomable = isMediaElement(el) && !el.closest('a');
-        if (isZoomable) {
-            el.classList.add(GALLERY_ITEM_CLASS);
-        }
-    });
-}
 
 export const getImageMimeType = (src: string): string => {
     const ext = src.split('.').pop()?.split(/[?#]/)[0]?.toLowerCase();


### PR DESCRIPTION
## Description

Added zoom-in cursor on gallery images after client-side navigation. 
Previously, gallery images were scanned only during the initial render, so newly rendered page content was not processed. The new implementation uses a delegated pointerover listener, allowing dynamically added images to be checked without rescanning the entire document. It applies the cursor only when isMediaElement confirms that the image can actually be opened in the gallery. This keeps the cursor behavior consistent with the gallery-opening logic, including explicit gallery attributes, image dimensions, links, and excluded elements. 
The solution works across SPA transitions while avoiding the additional complexity and overhead of mutation observers.