### PR TITLE
fix: add gallery-id attribute and tab logic

### DIFF
--- a/src/components/Gallery/hooks/useGalleryOpen.ts
+++ b/src/components/Gallery/hooks/useGalleryOpen.ts
@@ -1,7 +1,7 @@
 import {useCallback, useEffect} from 'react';
 import {useGallery} from '@gravity-ui/components';
 
-import {buildGalleryItem, isMediaElement} from '../utils';
+import {buildGalleryItem, getGalleryMedia, isMediaElement} from '../utils';
 
 export interface UseGalleryOpenProps {
     contentSelector: string;
@@ -17,17 +17,21 @@ export function useGalleryOpen({contentSelector}: UseGalleryOpenProps) {
             const clickedMedia = target.closest<HTMLElement>('img, svg');
             if (!clickedMedia || !isMediaElement(clickedMedia) || clickedMedia.closest('a')) return;
 
-            const container = clickedMedia.closest(contentSelector);
+            const container = clickedMedia.closest<HTMLElement>(contentSelector);
             if (!container) return;
 
             const allMedia = Array.from(
                 container.querySelectorAll<HTMLElement>('img, svg, .embed-responsive'),
             ).filter(isMediaElement);
+            const galleryMedia = getGalleryMedia(allMedia, clickedMedia, container);
 
-            const clickedIndex = allMedia.indexOf(clickedMedia);
+            const clickedIndex = galleryMedia.indexOf(clickedMedia);
             if (clickedIndex === -1) return;
 
-            openGallery(allMedia.map(buildGalleryItem), clickedIndex);
+            openGallery(
+                galleryMedia.map((media, index) => buildGalleryItem(media, index)),
+                clickedIndex,
+            );
         },
         [contentSelector, openGallery],
     );

--- a/src/components/Gallery/utils.tsx
+++ b/src/components/Gallery/utils.tsx
@@ -17,6 +17,9 @@ const INTERACTIVE_SELECTORS = [
 
 const MISC_EXCLUDED_SELECTORS = ['.dc-contributor-avatars__avatar', '[class*="background"]'];
 const EXCLUDED_PARENT_SELECTORS = [...INTERACTIVE_SELECTORS, ...MISC_EXCLUDED_SELECTORS].join(', ');
+const HEADING_SELECTOR = 'h1, h2, h3, h4, h5, h6';
+const TABS_SELECTOR = '.yfm-tabs';
+const TAB_PANEL_SELECTOR = '.yfm-tab-panel';
 
 export type GetGalleryItemVideoArgs = {
     index: number;
@@ -49,12 +52,83 @@ export const isSvgElement = (el: Element): el is SVGSVGElement => {
 export const isMediaElement = (el: HTMLElement): boolean => {
     if (isExcludedByParent(el)) return false;
 
+    if (el.dataset.galleryId) return true;
+
     const galleryAttr = el.dataset.gallery;
     if (galleryAttr === 'true') return true;
     if (galleryAttr === 'false') return false;
     if (el.dataset.gallerySrc) return true;
 
     return isContentSize(el);
+};
+
+const getGalleryId = (el: HTMLElement): string | undefined => el.dataset.galleryId || undefined;
+
+const getGroupingContext = (el: HTMLElement, container: HTMLElement): HTMLElement => {
+    const tabPanel = el.closest<HTMLElement>(TAB_PANEL_SELECTOR);
+
+    return tabPanel && container.contains(tabPanel) ? tabPanel : container;
+};
+
+const isBefore = (first: HTMLElement, second: HTMLElement): boolean =>
+    first.compareDocumentPosition(second) === Node.DOCUMENT_POSITION_FOLLOWING;
+
+const getPreviousBoundary = (
+    media: HTMLElement,
+    boundaries: HTMLElement[],
+): HTMLElement | undefined => {
+    let previousBoundary: HTMLElement | undefined;
+
+    for (const boundary of boundaries) {
+        if (boundary === media || boundary.contains(media) || !isBefore(boundary, media)) continue;
+
+        if (!previousBoundary || isBefore(previousBoundary, boundary)) {
+            previousBoundary = boundary;
+        }
+    }
+
+    return previousBoundary;
+};
+
+const getStructuralBoundaries = (
+    media: HTMLElement[],
+    context: HTMLElement,
+    container: HTMLElement,
+): HTMLElement[] => {
+    const structureSelector = context.matches(TAB_PANEL_SELECTOR)
+        ? TABS_SELECTOR
+        : `${HEADING_SELECTOR}, ${TABS_SELECTOR}`;
+    const structureBoundaries = Array.from(
+        context.querySelectorAll<HTMLElement>(structureSelector),
+    ).filter((el) => getGroupingContext(el, container) === context);
+    const explicitGalleryBoundaries = media.filter(
+        (el) => getGalleryId(el) && getGroupingContext(el, container) === context,
+    );
+
+    return [...structureBoundaries, ...explicitGalleryBoundaries];
+};
+
+export const getGalleryMedia = (
+    media: HTMLElement[],
+    clickedMedia: HTMLElement,
+    container: HTMLElement,
+): HTMLElement[] => {
+    const galleryId = getGalleryId(clickedMedia);
+
+    if (galleryId) {
+        return media.filter((el) => getGalleryId(el) === galleryId);
+    }
+
+    const context = getGroupingContext(clickedMedia, container);
+    const boundaries = getStructuralBoundaries(media, context, container);
+    const previousBoundary = getPreviousBoundary(clickedMedia, boundaries);
+
+    return media.filter(
+        (el) =>
+            !getGalleryId(el) &&
+            getGroupingContext(el, container) === context &&
+            getPreviousBoundary(el, boundaries) === previousBoundary,
+    );
 };
 
 export const getImageMimeType = (src: string): string => {

--- a/src/components/Gallery/utils.tsx
+++ b/src/components/Gallery/utils.tsx
@@ -20,6 +20,7 @@ const EXCLUDED_PARENT_SELECTORS = [...INTERACTIVE_SELECTORS, ...MISC_EXCLUDED_SE
 const HEADING_SELECTOR = 'h1, h2, h3, h4, h5, h6';
 const TABS_SELECTOR = '.yfm-tabs';
 const TAB_PANEL_SELECTOR = '.yfm-tab-panel';
+const MEDIA_SELECTOR = 'img, svg, .embed-responsive';
 
 export type GetGalleryItemVideoArgs = {
     index: number;
@@ -70,42 +71,42 @@ const getGroupingContext = (el: HTMLElement, container: HTMLElement): HTMLElemen
     return tabPanel && container.contains(tabPanel) ? tabPanel : container;
 };
 
-const isBefore = (first: HTMLElement, second: HTMLElement): boolean =>
-    first.compareDocumentPosition(second) === Node.DOCUMENT_POSITION_FOLLOWING;
-
-const getPreviousBoundary = (
-    media: HTMLElement,
-    boundaries: HTMLElement[],
-): HTMLElement | undefined => {
-    let previousBoundary: HTMLElement | undefined;
-
-    for (const boundary of boundaries) {
-        if (boundary === media || boundary.contains(media) || !isBefore(boundary, media)) continue;
-
-        if (!previousBoundary || isBefore(previousBoundary, boundary)) {
-            previousBoundary = boundary;
-        }
-    }
-
-    return previousBoundary;
-};
-
-const getStructuralBoundaries = (
+const getContextGalleryMedia = (
     media: HTMLElement[],
+    clickedMedia: HTMLElement,
     context: HTMLElement,
     container: HTMLElement,
 ): HTMLElement[] => {
     const structureSelector = context.matches(TAB_PANEL_SELECTOR)
         ? TABS_SELECTOR
         : `${HEADING_SELECTOR}, ${TABS_SELECTOR}`;
-    const structureBoundaries = Array.from(
-        context.querySelectorAll<HTMLElement>(structureSelector),
-    ).filter((el) => getGroupingContext(el, container) === context);
-    const explicitGalleryBoundaries = media.filter(
-        (el) => getGalleryId(el) && getGroupingContext(el, container) === context,
+    const mediaSet = new Set(media);
+    const elements = Array.from(
+        context.querySelectorAll<HTMLElement>(`${structureSelector}, ${MEDIA_SELECTOR}`),
     );
+    let currentGroup: HTMLElement[] = [];
 
-    return [...structureBoundaries, ...explicitGalleryBoundaries];
+    for (const element of elements) {
+        if (getGroupingContext(element, container) !== context) continue;
+
+        const isGalleryMedia = mediaSet.has(element);
+        const isBoundary =
+            element.matches(structureSelector) ||
+            (isGalleryMedia && Boolean(getGalleryId(element)));
+
+        if (isBoundary) {
+            if (currentGroup.includes(clickedMedia)) return currentGroup;
+
+            currentGroup = [];
+            continue;
+        }
+
+        if (isGalleryMedia) {
+            currentGroup.push(element);
+        }
+    }
+
+    return currentGroup.includes(clickedMedia) ? currentGroup : [];
 };
 
 export const getGalleryMedia = (
@@ -120,15 +121,8 @@ export const getGalleryMedia = (
     }
 
     const context = getGroupingContext(clickedMedia, container);
-    const boundaries = getStructuralBoundaries(media, context, container);
-    const previousBoundary = getPreviousBoundary(clickedMedia, boundaries);
 
-    return media.filter(
-        (el) =>
-            !getGalleryId(el) &&
-            getGroupingContext(el, container) === context &&
-            getPreviousBoundary(el, boundaries) === previousBoundary,
-    );
+    return getContextGalleryMedia(media, clickedMedia, context, container);
 };
 
 export const getImageMimeType = (src: string): string => {


### PR DESCRIPTION
## Description

Added support for grouping images into multiple independent galleries. 
Images without an explicit gallery-id are grouped within the same heading section, while each YFM tab panel creates a separate gallery context. 
Tab blocks also split the surrounding images into independent groups. 
Images with the same gallery-id are grouped globally, even when located in different sections or tabs. 
A non-empty gallery-id is treated as an explicit gallery opt-in, equivalent to gallery=true. 

Tests cover heading boundaries, tab panels, explicit IDs, and separation between explicitly grouped and regular images.