### PR TITLE
feat: добавить сворачиваемое оглавление

### DIFF
--- a/demo/Components/DocPage/index.stories.tsx
+++ b/demo/Components/DocPage/index.stories.tsx
@@ -1,5 +1,6 @@
 import type {RenderSidebarIcon, VcsType} from '@diplodoc/components';
 
+import {useState} from 'react';
 import {Icon, configure as configureUikit} from '@gravity-ui/uikit';
 import cn from 'bem-cn-lite';
 import {Dots9, SquareListUl, Xmark} from '@gravity-ui/icons';
@@ -40,6 +41,7 @@ const DocPageDemo = (
         langs: extendedLangs,
         withConsent: true,
     });
+    const [tocCollapsed, setTocCollapsed] = useState(false);
 
     const content = getContent(lang, singlePage);
 
@@ -71,6 +73,8 @@ const DocPageDemo = (
                 availableLangs={resolveAvailableLangs(args['AvailableLangs'])}
                 beforeSubNavigationContent={mobileView ? undefined : beforeSubNavigationContent}
                 renderSidebarIcon={renderSidebarIcon}
+                tocCollapsed={args['CollapsibleToc'] ? tocCollapsed : undefined}
+                onChangeTocCollapsed={args['CollapsibleToc'] ? setTocCollapsed : undefined}
                 // TODO: return highlight examples
                 // onContentMutation={onContentMutation}
                 // onContentLoaded={onContentLoaded}
@@ -87,6 +91,7 @@ export default {
         HideTocHeader: {control: 'boolean'},
         HideFeedback: {control: 'boolean'},
         HideAsideFeedback: {control: 'boolean'},
+        CollapsibleToc: {control: 'boolean'},
         AvailableLangs: availableLangsArgType,
     },
 };
@@ -97,5 +102,6 @@ export const Document = {
         HideTocHeader: false,
         HideFeedback: false,
         HideAsideFeedback: false,
+        CollapsibleToc: false,
     },
 };

--- a/src/components/DocContentPage/DocContentPage.tsx
+++ b/src/components/DocContentPage/DocContentPage.tsx
@@ -21,6 +21,8 @@ export interface DocContentPageProps extends DocContentPageData {
     useMainTag?: boolean;
     legacyToc?: boolean;
     fullScreen?: boolean;
+    tocCollapsed?: boolean;
+    onChangeTocCollapsed?: (value: boolean) => void;
     viewerInterface?: Record<string, boolean>;
     hideTocHeader?: boolean;
     pdfLink?: string;
@@ -40,6 +42,8 @@ export const DocContentPage: React.FC<DocContentPageProps> = ({
     useMainTag,
     legacyToc,
     fullScreen,
+    tocCollapsed,
+    onChangeTocCollapsed,
     hideTocHeader,
     pdfLink,
     textSize,
@@ -57,6 +61,8 @@ export const DocContentPage: React.FC<DocContentPageProps> = ({
             className={b(modes)}
             hideToc={hideToc}
             fullScreen={fullScreen || data?.fullScreen}
+            tocCollapsed={tocCollapsed}
+            onChangeTocCollapsed={onChangeTocCollapsed}
             tocTitleIcon={tocTitleIcon}
             footer={footer}
             hideRight={true}

--- a/src/components/DocLayout/DocLayout.scss
+++ b/src/components/DocLayout/DocLayout.scss
@@ -79,11 +79,13 @@
             display: flex;
             flex-direction: column;
             height: calc(100vh - var(--dc-header-height, #{variables.$headerHeight}));
+            border-right: 1px solid var(--g-color-line-generic);
 
             > .dc-toc {
                 flex: 1 1 auto;
                 min-height: 0;
                 height: auto;
+                border-right: none;
             }
         }
 
@@ -110,7 +112,6 @@
         display: flex;
         align-items: center;
         justify-content: center;
-        border-top: 1px solid var(--g-color-line-generic);
         position: relative;
         box-sizing: content-box;
 
@@ -221,6 +222,7 @@
             width: 100%;
             height: 100%;
             padding: 0;
+            border-right: none;
 
             @include mixins.text-size(body-2);
 

--- a/src/components/DocLayout/DocLayout.scss
+++ b/src/components/DocLayout/DocLayout.scss
@@ -35,6 +35,10 @@
         width: 276px;
         transition: width 150ms ease-out;
 
+        @media (prefers-reduced-motion: reduce) {
+            transition: none;
+        }
+
         &_full-screen {
             flex: initial;
         }
@@ -264,12 +268,6 @@
             &_toc-collapsed {
                 width: 56px;
             }
-        }
-    }
-
-    @media (prefers-reduced-motion: reduce) {
-        &__left {
-            transition: none;
         }
     }
 }

--- a/src/components/DocLayout/DocLayout.scss
+++ b/src/components/DocLayout/DocLayout.scss
@@ -1,4 +1,5 @@
 @use 'sass:map';
+@use '@gravity-ui/uikit/styles/mixins' as gravityMixins;
 @use '../../styles/variables';
 @use '../../styles/mixins';
 
@@ -32,9 +33,14 @@
     &__left {
         order: 1;
         width: 276px;
+        transition: width 150ms ease-out;
 
         &_full-screen {
             flex: initial;
+        }
+
+        &_toc-collapsed {
+            width: 56px;
         }
     }
 
@@ -68,6 +74,75 @@
         box-sizing: content-box;
         background-color: var(--g-color-base-background);
         @include mixins.text-size(body-1);
+
+        &_collapsible {
+            display: flex;
+            flex-direction: column;
+            height: calc(100vh - var(--dc-header-height, #{variables.$headerHeight}));
+
+            > .dc-toc {
+                flex: 1 1 auto;
+                min-height: 0;
+                height: auto;
+            }
+        }
+
+        &_toc-collapsed {
+            width: 56px;
+            padding-left: 0;
+
+            > .dc-toc {
+                display: none;
+            }
+        }
+    }
+
+    &__toc-collapse-button {
+        --_--focus-outline-color: var(--g-color-line-focus);
+        --_--focus-outline-offset: 0;
+
+        @include gravityMixins.button-reset();
+
+        flex: 0 0 auto;
+        min-height: 20px;
+        width: calc(100% + 24px);
+        margin-left: -24px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        border-top: 1px solid var(--g-color-line-generic);
+        position: relative;
+        box-sizing: content-box;
+
+        &::before {
+            content: '';
+            position: absolute;
+            z-index: -1;
+            inset: 0 2px 2px;
+        }
+
+        &:focus-visible::before {
+            outline: var(--_--focus-outline-color) solid 2px;
+            outline-offset: var(--_--focus-outline-offset);
+        }
+
+        &:not(&_collapsed) &-icon {
+            transform: rotate(180deg);
+        }
+
+        &:hover &-icon {
+            color: var(--g-color-text-primary);
+        }
+
+        &_collapsed {
+            width: 100%;
+            margin-left: 0;
+            margin-top: auto;
+        }
+
+        &-icon {
+            color: var(--g-color-text-secondary);
+        }
     }
 
     &__desktop-only {
@@ -153,6 +228,14 @@
                 /* stylelint-disable-next-line declaration-no-important */
                 height: 100% !important;
             }
+
+            &_toc-collapsed > .dc-toc {
+                display: flex;
+            }
+        }
+
+        &__toc-collapse-button {
+            display: none;
         }
     }
 
@@ -167,10 +250,24 @@
 
         &__toc {
             width: 252px;
+
+            &_toc-collapsed {
+                width: 56px;
+            }
         }
 
         &__left {
             width: 276px;
+
+            &_toc-collapsed {
+                width: 56px;
+            }
+        }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+        &__left {
+            transition: none;
         }
     }
 }

--- a/src/components/DocLayout/DocLayout.tsx
+++ b/src/components/DocLayout/DocLayout.tsx
@@ -5,6 +5,7 @@ import React from 'react';
 import block from 'bem-cn-lite';
 
 import {getStateKey} from '../../utils';
+import {useTranslation} from '../../hooks';
 import {Toc} from '../Toc';
 import {useInterface} from '../../hooks/useInterface';
 
@@ -34,6 +35,8 @@ export interface DocLayoutProps {
     footer?: React.ReactNode;
     singlePage?: boolean;
     legacyToc?: boolean;
+    tocCollapsed?: boolean;
+    onChangeTocCollapsed?: (value: boolean) => void;
     onChangeSinglePage?: (value: boolean) => void;
     pdfLink?: string;
     pdfIconConfig?: {position?: string; size?: 'S' | 'M' | 'L'; icon?: string};
@@ -45,6 +48,40 @@ type DocLayoutStatic = {
     Right: React.FC<PropsWithChildren>;
 };
 
+interface TocCollapseButtonProps {
+    collapsed: boolean;
+    controls: string;
+    onChange: (value: boolean) => void;
+}
+
+const TocCollapseButton: React.FC<TocCollapseButtonProps> = ({collapsed, controls, onChange}) => {
+    const {t} = useTranslation('controls');
+    const title = collapsed ? t('expand-toc-text') : t('collapse-toc-text');
+
+    return (
+        <button
+            type="button"
+            className={b('toc-collapse-button', {collapsed})}
+            title={title}
+            aria-label={title}
+            aria-controls={controls}
+            aria-expanded={!collapsed}
+            onClick={() => onChange(!collapsed)}
+        >
+            <svg
+                className={b('toc-collapse-button-icon')}
+                width="16"
+                height="10"
+                viewBox="0 0 8 8"
+                fill="currentColor"
+                aria-hidden="true"
+            >
+                <path d="m.72 7.64 6.39-3.2a.5.5 0 0 0 0-.89L.72.36A.5.5 0 0 0 0 .81v6.38c0 .37.4.61.72.45Z" />
+            </svg>
+        </button>
+    );
+};
+
 export const DocLayout: React.FC<DocLayoutProps> & DocLayoutStatic = ({
     children,
     className,
@@ -54,11 +91,13 @@ export const DocLayout: React.FC<DocLayoutProps> & DocLayoutStatic = ({
     loading = false,
     footer = null,
     legacyToc = false,
+    tocCollapsed = false,
     toc,
     router,
     headerHeight,
     tocTitleIcon,
     hideToc,
+    onChangeTocCollapsed,
     singlePage,
     onChangeSinglePage,
     pdfLink,
@@ -67,6 +106,9 @@ export const DocLayout: React.FC<DocLayoutProps> & DocLayoutStatic = ({
 }) => {
     const isTocHidden = useInterface('toc');
     const isTocHeaderHidden = useInterface('toc-header');
+    const tocId = React.useId();
+    const tocCollapsible = Boolean(toc && !hideToc && !legacyToc && onChangeTocCollapsed);
+    const isTocCollapsed = tocCollapsible && tocCollapsed;
 
     let left, center, right;
     const modes = {
@@ -100,12 +142,24 @@ export const DocLayout: React.FC<DocLayoutProps> & DocLayoutStatic = ({
             {fullScreen
                 ? null
                 : !isTocHidden && (
-                      <div className={b('left', modes, legacyToc ? b('legacy-toc') : undefined)}>
+                      <div
+                          className={b(
+                              'left',
+                              {...modes, 'toc-collapsed': isTocCollapsed},
+                              legacyToc ? b('legacy-toc') : undefined,
+                          )}
+                      >
                           {toc && !hideToc && (
-                              <div className={b('toc')}>
+                              <div
+                                  className={b('toc', {
+                                      collapsible: tocCollapsible,
+                                      'toc-collapsed': isTocCollapsed,
+                                  })}
+                              >
                                   <Toc
                                       key={getStateKey(hideRight, wideFormat, toc.singlePage)}
                                       {...toc}
+                                      id={tocId}
                                       router={router}
                                       headerHeight={headerHeight}
                                       tocTitleIcon={tocTitleIcon}
@@ -115,6 +169,13 @@ export const DocLayout: React.FC<DocLayoutProps> & DocLayoutStatic = ({
                                       pdfLink={pdfLink}
                                       pdfIconConfig={pdfIconConfig}
                                   />
+                                  {tocCollapsible && onChangeTocCollapsed && (
+                                      <TocCollapseButton
+                                          collapsed={isTocCollapsed}
+                                          controls={tocId}
+                                          onChange={onChangeTocCollapsed}
+                                      />
+                                  )}
                               </div>
                           )}
                           {left}

--- a/src/components/DocLeadingPage/DocLeadingPage.tsx
+++ b/src/components/DocLeadingPage/DocLeadingPage.tsx
@@ -31,6 +31,8 @@ export interface DocLeadingPageProps extends DocLeadingPageData, NotificationPro
     legacyToc?: boolean;
     isMobile?: boolean;
     fullScreen?: boolean;
+    tocCollapsed?: boolean;
+    onChangeTocCollapsed?: (value: boolean) => void;
     pdfLink?: string;
     textSize?: TextSizes;
 }
@@ -135,6 +137,8 @@ export const DocLeadingPage: React.FC<DocLeadingPageProps> = ({
     notificationCb,
     isMobile,
     fullScreen,
+    tocCollapsed,
+    onChangeTocCollapsed,
     pdfLink,
     textSize,
 }) => {
@@ -154,6 +158,8 @@ export const DocLeadingPage: React.FC<DocLeadingPageProps> = ({
             footer={footer}
             legacyToc={legacyToc}
             fullScreen={fullScreen}
+            tocCollapsed={tocCollapsed}
+            onChangeTocCollapsed={onChangeTocCollapsed}
             pdfLink={pdfLink}
         >
             <DocLayout.Center>

--- a/src/components/DocPage/DocPage.tsx
+++ b/src/components/DocPage/DocPage.tsx
@@ -80,6 +80,8 @@ export interface DocPageProps extends DocPageData, DocSettings, NotificationProp
     onChangeLang?: (lang: `${Lang}` | Lang, options?: LangOptions) => void;
     onChangeFullScreen?: (value: boolean) => void;
     onChangeSinglePage?: (value: boolean) => void;
+    tocCollapsed?: boolean;
+    onChangeTocCollapsed?: (value: boolean) => void;
     onChangeWideFormat?: (value: boolean) => void;
     onChangeShowMiniToc?: (value: boolean) => void;
     onChangeBookmarkPage?: (value: boolean) => void;
@@ -178,6 +180,8 @@ class DocPage extends React.Component<DocPageInnerProps, DocPageState> {
             hideToc,
             footer,
             onChangeSinglePage,
+            tocCollapsed,
+            onChangeTocCollapsed,
             pdfIconConfig,
             useMainTag,
             onChangeLang,
@@ -227,6 +231,8 @@ class DocPage extends React.Component<DocPageInnerProps, DocPageState> {
                 footer={footer}
                 singlePage={singlePage}
                 onChangeSinglePage={onChangeSinglePage}
+                tocCollapsed={tocCollapsed}
+                onChangeTocCollapsed={onChangeTocCollapsed}
                 pdfLink={tocPdfLink}
                 pdfIconConfig={pdfIconConfig}
                 legacyToc={legacyToc}

--- a/src/components/Toc/Toc.tsx
+++ b/src/components/Toc/Toc.tsx
@@ -22,6 +22,7 @@ function zip<T>(array: string[], fill: T): Record<string, T> {
 }
 
 export interface TocProps extends TocData {
+    id?: string;
     router: Router;
     headerHeight?: number;
     tocTitleIcon?: React.ReactNode;
@@ -111,11 +112,11 @@ class TocClass extends React.Component<TocInternalProps, TocState> {
     }
 
     render() {
-        const {items, hideTocHeader, extraHeader} = this.props;
+        const {id, items, hideTocHeader, extraHeader} = this.props;
         const content = items ? this.renderList(items) : this.renderEmpty('');
 
         return (
-            <nav className={b()} ref={this.rootRef}>
+            <nav id={id} className={b()} ref={this.rootRef}>
                 {this.renderTop()}
                 <div
                     className={b('content', {

--- a/src/components/Toc/__tests__/Toc.spec.ts
+++ b/src/components/Toc/__tests__/Toc.spec.ts
@@ -97,10 +97,36 @@ test('Collapses and expands the documentation table of contents', async ({page})
     await expect(toc).toBeVisible();
 });
 
-test('Keeps the table of contents available on mobile', async ({page}) => {
-    await page.setViewportSize({width: 375, height: 800});
+test('Keeps the table of contents available after resizing to mobile', async ({page}) => {
     await loadDocumentPage(page, DOC_PAGE_COLLAPSIBLE_TOC_URL);
 
-    await expect(page.getByRole('button', {name: 'Collapse table of contents'})).toBeHidden();
-    await expect(page.locator('.dc-toc')).toHaveCSS('display', 'flex');
+    const toc = page.locator('.dc-toc');
+    const collapseButton = page.getByRole('button', {name: 'Collapse table of contents'});
+
+    await collapseButton.click();
+    await expect(toc).toBeHidden();
+
+    await page.setViewportSize({width: 375, height: 800});
+
+    await expect(page.getByRole('button', {name: 'Expand table of contents'})).toBeHidden();
+    await expect(toc).toHaveCSS('display', 'flex');
+});
+
+test('Does not show the collapse button without a change handler', async ({page}) => {
+    await loadDocumentPage(page);
+
+    await expect(page.locator('.dc-doc-layout__toc-collapse-button')).toHaveCount(0);
+});
+
+test('Preserves the mobile navigation transition with reduced motion', async ({page}) => {
+    await page.emulateMedia({reducedMotion: 'reduce'});
+    await loadDocumentPage(page, DOC_PAGE_COLLAPSIBLE_TOC_URL);
+
+    const layout = page.locator('.dc-doc-layout__left');
+
+    await expect(layout).toHaveCSS('transition-property', 'none');
+
+    await page.setViewportSize({width: 375, height: 800});
+
+    await expect(layout).toHaveCSS('transition-property', 'left');
 });

--- a/src/components/Toc/__tests__/Toc.spec.ts
+++ b/src/components/Toc/__tests__/Toc.spec.ts
@@ -1,6 +1,10 @@
 import {expect, test} from '@playwright/test';
 
-import {DOC_PAGE_HEADER_HIDDEN_URL, DOC_PAGE_HEADER_SHOWN_URL} from '../../constants';
+import {
+    DOC_PAGE_COLLAPSIBLE_TOC_URL,
+    DOC_PAGE_HEADER_HIDDEN_URL,
+    DOC_PAGE_HEADER_SHOWN_URL,
+} from '../../constants';
 import {loadDocumentPage} from '../../utils';
 
 test.beforeEach(async ({page}) => {
@@ -52,4 +56,45 @@ test.describe('Toc header screenshot tests', () => {
             maxDiffPixelRatio: 0.01,
         });
     });
+});
+
+test('Collapses and expands the documentation table of contents', async ({page}) => {
+    await loadDocumentPage(page, DOC_PAGE_COLLAPSIBLE_TOC_URL);
+
+    const layout = page.locator('.dc-doc-layout__left');
+    const toc = page.locator('.dc-toc');
+    const collapseButton = page.getByRole('button', {name: 'Collapse table of contents'});
+    const icon = collapseButton.locator('svg');
+    const tocId = await toc.getAttribute('id');
+
+    await expect(collapseButton).toHaveAttribute('aria-expanded', 'true');
+    expect(tocId).toBeTruthy();
+    await expect(collapseButton).toHaveAttribute('aria-controls', tocId || '');
+    await expect(layout).toHaveCSS('width', '276px');
+    await expect(icon).toHaveAttribute('viewBox', '0 0 8 8');
+    await expect(icon.locator('path')).toHaveAttribute(
+        'd',
+        'm.72 7.64 6.39-3.2a.5.5 0 0 0 0-.89L.72.36A.5.5 0 0 0 0 .81v6.38c0 .37.4.61.72.45Z',
+    );
+
+    await collapseButton.click();
+
+    const expandButton = page.getByRole('button', {name: 'Expand table of contents'});
+    await expect(expandButton).toHaveAttribute('aria-expanded', 'false');
+    await expect(layout).toHaveCSS('width', '56px');
+    await expect(toc).toBeHidden();
+
+    await expandButton.click();
+
+    await expect(collapseButton).toHaveAttribute('aria-expanded', 'true');
+    await expect(layout).toHaveCSS('width', '276px');
+    await expect(toc).toBeVisible();
+});
+
+test('Keeps the table of contents available on mobile', async ({page}) => {
+    await page.setViewportSize({width: 375, height: 800});
+    await loadDocumentPage(page, DOC_PAGE_COLLAPSIBLE_TOC_URL);
+
+    await expect(page.getByRole('button', {name: 'Collapse table of contents'})).toBeHidden();
+    await expect(page.locator('.dc-toc')).toHaveCSS('display', 'flex');
 });

--- a/src/components/Toc/__tests__/Toc.spec.ts
+++ b/src/components/Toc/__tests__/Toc.spec.ts
@@ -62,12 +62,18 @@ test('Collapses and expands the documentation table of contents', async ({page})
     await loadDocumentPage(page, DOC_PAGE_COLLAPSIBLE_TOC_URL);
 
     const layout = page.locator('.dc-doc-layout__left');
+    const tocWrapper = page.locator('.dc-doc-layout__toc');
     const toc = page.locator('.dc-toc');
     const collapseButton = page.getByRole('button', {name: 'Collapse table of contents'});
     const icon = collapseButton.locator('svg');
     const tocId = await toc.getAttribute('id');
 
     await expect(collapseButton).toHaveAttribute('aria-expanded', 'true');
+    await expect(collapseButton).toHaveCSS('border-top-width', '0px');
+    await expect(tocWrapper).toHaveCSS('border-right-width', '1px');
+    expect(await tocWrapper.evaluate((element) => element.getBoundingClientRect().bottom)).toBe(
+        await page.evaluate(() => window.innerHeight),
+    );
     expect(tocId).toBeTruthy();
     await expect(collapseButton).toHaveAttribute('aria-controls', tocId || '');
     await expect(layout).toHaveCSS('width', '276px');

--- a/src/components/constants.ts
+++ b/src/components/constants.ts
@@ -14,6 +14,8 @@ export const DOC_PAGE_HEADER_HIDDEN_URL =
     BASE_URL + '/iframe.html?args=HideTocHeader:true&id=pages-document--document&viewMode=story';
 export const DOC_PAGE_HEADER_SHOWN_URL =
     BASE_URL + '/iframe.html?args=HideTocHeader:false&id=pages-document--document&viewMode=story';
+export const DOC_PAGE_COLLAPSIBLE_TOC_URL =
+    BASE_URL + '/iframe.html?args=CollapsibleToc:true&id=pages-document--document&viewMode=story';
 export const DOC_PAGE_FEEDBACK_HIDDEN_URL =
     BASE_URL + '/iframe.html?args=HideFeedback:true&id=pages-document--document&viewMode=story';
 export const DOC_PAGE_FEEDBACK_SHOWN_URL =

--- a/src/i18n/ar.json
+++ b/src/i18n/ar.json
@@ -4,6 +4,8 @@
     "description_wide_format_enabled": "مفعل",
     "description_wide_format_disabled": "معطل",
     "label_show_mini_toc": "قوالب التصفح في المقال",
+    "collapse-toc-text": "طي جدول المحتويات",
+    "expand-toc-text": "توسيع جدول المحتويات",
     "description_show_mini_toc_enabled": "مُفعلة",
     "description_show_mini_toc_disabled": "مُعطلة",
     "label_theme": "نمط",

--- a/src/i18n/bg.json
+++ b/src/i18n/bg.json
@@ -4,6 +4,8 @@
     "description_wide_format_enabled": "Включен",
     "description_wide_format_disabled": "Изключен",
     "label_show_mini_toc": "Навигация в текущата статия",
+    "collapse-toc-text": "Свиване на съдържанието",
+    "expand-toc-text": "Разгъване на съдържанието",
     "description_show_mini_toc_enabled": "Включена",
     "description_show_mini_toc_disabled": "Изключена",
     "label_theme": "Тема",

--- a/src/i18n/cs.json
+++ b/src/i18n/cs.json
@@ -4,6 +4,8 @@
     "description_wide_format_enabled": "Povoleno",
     "description_wide_format_disabled": "Zakázáno",
     "label_show_mini_toc": "Navigace k článku",
+    "collapse-toc-text": "Sbalit obsah",
+    "expand-toc-text": "Rozbalit obsah",
     "description_show_mini_toc_enabled": "Zapnuto",
     "description_show_mini_toc_disabled": "Vypnuto",
     "label_theme": "Téma",

--- a/src/i18n/el.json
+++ b/src/i18n/el.json
@@ -4,6 +4,8 @@
     "description_wide_format_enabled": "Ενεργοποιημένη",
     "description_wide_format_disabled": "Απενεργοποιημένη",
     "label_show_mini_toc": "Πλοήγηση τρέχοντος άρθρου",
+    "collapse-toc-text": "Σύμπτυξη πίνακα περιεχομένων",
+    "expand-toc-text": "Ανάπτυξη πίνακα περιεχομένων",
     "description_show_mini_toc_enabled": "Ενεργοποιημένη",
     "description_show_mini_toc_disabled": "Απενεργοποιημένη",
     "label_theme": "Θέμα",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -4,6 +4,8 @@
     "description_wide_format_enabled": "Enabled",
     "description_wide_format_disabled": "Disabled",
     "label_show_mini_toc": "Navigation for the article",
+    "collapse-toc-text": "Collapse table of contents",
+    "expand-toc-text": "Expand table of contents",
     "description_show_mini_toc_enabled": "Enabled",
     "description_show_mini_toc_disabled": "Disabled",
     "label_theme": "Theme",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -4,6 +4,8 @@
     "description_wide_format_enabled": "Habilitado",
     "description_wide_format_disabled": "Deshabilitado",
     "label_show_mini_toc": "Navegación por el artículo",
+    "collapse-toc-text": "Contraer la tabla de contenido",
+    "expand-toc-text": "Expandir la tabla de contenido",
     "description_show_mini_toc_enabled": "Activada",
     "description_show_mini_toc_disabled": "Desactivada",
     "label_theme": "Tema",

--- a/src/i18n/et.json
+++ b/src/i18n/et.json
@@ -4,6 +4,8 @@
     "description_wide_format_enabled": "Sisselülitatud",
     "description_wide_format_disabled": "Väljalülitatud",
     "label_show_mini_toc": "Praeguses artiklis navigeerimine",
+    "collapse-toc-text": "Ahenda sisukord",
+    "expand-toc-text": "Laienda sisukorda",
     "description_show_mini_toc_enabled": "Sisselülitatud",
     "description_show_mini_toc_disabled": "Väljalülitatud",
     "label_theme": "Teema",

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -4,6 +4,8 @@
     "description_wide_format_enabled": "Activé",
     "description_wide_format_disabled": "Désactivé",
     "label_show_mini_toc": "Navigation pour l’article",
+    "collapse-toc-text": "Réduire la table des matières",
+    "expand-toc-text": "Développer la table des matières",
     "description_show_mini_toc_enabled": "Activée",
     "description_show_mini_toc_disabled": "Désactivée",
     "label_theme": "Thème",

--- a/src/i18n/he.json
+++ b/src/i18n/he.json
@@ -4,6 +4,8 @@
     "description_wide_format_enabled": "התאפשר",
     "description_wide_format_disabled": "הושבת",
     "label_show_mini_toc": "ניווט לכתבה",
+    "collapse-toc-text": "כיווץ תוכן העניינים",
+    "expand-toc-text": "הרחבת תוכן העניינים",
     "description_show_mini_toc_enabled": "מופעלת",
     "description_show_mini_toc_disabled": "מושבתת",
     "label_theme": "נושא",

--- a/src/i18n/kk.json
+++ b/src/i18n/kk.json
@@ -4,6 +4,8 @@
     "description_wide_format_enabled": "Қосулы",
     "description_wide_format_disabled": "Сөндірулі",
     "label_show_mini_toc": "Ағымдағы мақала бойынша навигация",
+    "collapse-toc-text": "Мазмұнды жию",
+    "expand-toc-text": "Мазмұнды жаю",
     "description_show_mini_toc_enabled": "Қосулы",
     "description_show_mini_toc_disabled": "Өшірулі",
     "label_theme": "Тақырып",

--- a/src/i18n/pt.json
+++ b/src/i18n/pt.json
@@ -4,6 +4,8 @@
     "description_wide_format_enabled": "Ligado",
     "description_wide_format_disabled": "Desligado",
     "label_show_mini_toc": "Navegar nesta página",
+    "collapse-toc-text": "Recolher o índice",
+    "expand-toc-text": "Expandir o índice",
     "description_show_mini_toc_enabled": "Ativada",
     "description_show_mini_toc_disabled": "Desativada",
     "label_theme": "Tema",

--- a/src/i18n/ru.json
+++ b/src/i18n/ru.json
@@ -4,6 +4,8 @@
     "description_wide_format_enabled": "Включен",
     "description_wide_format_disabled": "Выключен",
     "label_show_mini_toc": "Навигация по текущей статье",
+    "collapse-toc-text": "Свернуть оглавление",
+    "expand-toc-text": "Развернуть оглавление",
     "description_show_mini_toc_enabled": "Включена",
     "description_show_mini_toc_disabled": "Выключена",
     "label_theme": "Тема",

--- a/src/i18n/tr.json
+++ b/src/i18n/tr.json
@@ -4,6 +4,8 @@
     "description_wide_format_enabled": "Açık",
     "description_wide_format_disabled": "Kapalı",
     "label_show_mini_toc": "Yazı içi navigasyon",
+    "collapse-toc-text": "İçindekiler bölümünü daralt",
+    "expand-toc-text": "İçindekiler bölümünü genişlet",
     "description_show_mini_toc_enabled": "Etkin",
     "description_show_mini_toc_disabled": "Devre dışı",
     "label_theme": "Tema",

--- a/src/i18n/uz.json
+++ b/src/i18n/uz.json
@@ -4,6 +4,8 @@
     "description_wide_format_enabled": "Yoqilgan",
     "description_wide_format_disabled": "Oʻchirilgan",
     "label_show_mini_toc": "Joriy maqola ichida navigatsiya",
+    "collapse-toc-text": "Mundarijani yig‘ish",
+    "expand-toc-text": "Mundarijani yoyish",
     "description_show_mini_toc_enabled": "Yoqilgan",
     "description_show_mini_toc_disabled": "O'chirilgan",
     "label_theme": "Mavzu",

--- a/src/i18n/zh-tw.json
+++ b/src/i18n/zh-tw.json
@@ -4,6 +4,8 @@
     "description_wide_format_enabled": "已開啓",
     "description_wide_format_disabled": "已關閉",
     "label_show_mini_toc": "浏覽當前文章",
+    "collapse-toc-text": "收合目錄",
+    "expand-toc-text": "展開目錄",
     "description_show_mini_toc_enabled": "已啟用",
     "description_show_mini_toc_disabled": "已停用",
     "label_theme": "主題",

--- a/src/i18n/zh.json
+++ b/src/i18n/zh.json
@@ -4,6 +4,8 @@
     "description_wide_format_enabled": "已开启",
     "description_wide_format_disabled": "已关闭",
     "label_show_mini_toc": "浏览当前文章",
+    "collapse-toc-text": "折叠目录",
+    "expand-toc-text": "展开目录",
     "description_show_mini_toc_enabled": "已启用",
     "description_show_mini_toc_disabled": "已禁用",
     "label_theme": "主题",


### PR DESCRIPTION
## Описание

Добавляет управляемое сворачивание левого оглавления документации:

- публичные свойства `tocCollapsed` и `onChangeTocCollapsed` для `DocLayout`, `DocPage`, `DocContentPage` и `DocLeadingPage`;
- компактное состояние шириной 56 px с освобождением места под основной контент;
- нижнюю кнопку с той же геометрией стрелки и визуальным поведением, что у `CollapseButton` в Gravity UI `AsideHeader`;
- локализованные доступные названия, `aria-expanded` и связь с оглавлением через `aria-controls`;
- сохранение обычного мобильного сценария без дополнительной кнопки;
- Storybook-переключатель и Playwright-проверки разворачивания, сворачивания, SVG и мобильного поведения.

Компонент остаётся управляемым: приложение-владелец хранит состояние и при необходимости может сохранять пользовательский выбор.

## Проверки

- `npm run build` — пройдено;
- `npm run lint -- --no-fix` — ошибок нет, остаётся существующее предупреждение о сложности в `Controls.tsx`;
- отдельная проверка типов библиотеки, Storybook и тестов — пройдена; сводный `npm run typecheck` в текущем `master` воспроизводит конфигурационную ошибку TS5070 (`resolveJsonModule` с классическим `moduleResolution`);
- Playwright, Chromium — 8/8;
- развёрнутое и свёрнутое состояния проверены визуально при 1440 × 900, включая геометрию 276 → 56 px.

Firefox и WebKit локально не запускались: соответствующие браузерные бинарники не установлены. GitHub Actions репозитория устанавливает все три движка.
