### PR TITLE
fix: add markdown buttons

### DIFF
--- a/src/components/Controls/Controls.tsx
+++ b/src/components/Controls/Controls.tsx
@@ -17,6 +17,7 @@ import {Subscribe, SubscribeView} from '../Subscribe';
 import {useInterface} from '../../hooks';
 
 import {ControlsLayoutContext} from './ControlsLayout';
+import MarkdownControl from './single-controls/MarkdownControl';
 
 import {
     DividerControl,
@@ -61,6 +62,9 @@ export interface ControlsProps {
     hideEditControl?: boolean;
     hideFeedbackControls?: boolean;
     availableLangs?: AvailableLangs;
+    showMarkdownActions?: boolean;
+    mdDocsUrl?: string;
+    onMdDocsButtonClick?: React.MouseEventHandler<HTMLElement>;
 }
 
 const b = block('dc-controls');
@@ -108,6 +112,9 @@ export const ControlsList: React.FC<
         isHiddenAsideFeedback,
         availableLangs = [],
         className,
+        showMarkdownActions,
+        mdDocsUrl,
+        onMdDocsButtonClick,
     } = props;
 
     const {isVerticalView} = useContext(ControlsLayoutContext);
@@ -200,6 +207,13 @@ export const ControlsList: React.FC<
                 onSubscribe={onSubscribe as Defined['onSubscribe']}
                 consentContent={consentContent}
                 view={SubscribeView.Regular}
+            />
+        ),
+        showMarkdownActions && (
+            <MarkdownControl
+                key="markdown-control"
+                mdDocsUrl={mdDocsUrl}
+                onClick={onMdDocsButtonClick}
             />
         ),
     ]

--- a/src/components/Controls/__tests__/Controls.spec.ts
+++ b/src/components/Controls/__tests__/Controls.spec.ts
@@ -7,6 +7,68 @@ test.beforeEach(async ({page}) => {
 });
 
 test.describe('Controls test', () => {
+    test('Markdown actions are rendered in controls', async ({page}) => {
+        const markdown = '# Markdown companion';
+        const markdownUrl = '/docs/overview/index.md';
+
+        await page.route(`**${markdownUrl}`, async (route) => {
+            expect(route.request().headers().accept).toBe('text/markdown');
+            await route.fulfill({body: markdown, contentType: 'text/markdown'});
+        });
+        await page.evaluate(() => {
+            Object.defineProperty(navigator, 'clipboard', {
+                configurable: true,
+                value: {
+                    writeText: (value: string) => {
+                        (window as typeof window & {copiedMarkdown?: string}).copiedMarkdown =
+                            value;
+                        return Promise.resolve();
+                    },
+                },
+            });
+            Object.defineProperty(window, 'open', {
+                configurable: true,
+                value: (url: string) => {
+                    (window as typeof window & {openedMarkdownUrl?: string}).openedMarkdownUrl =
+                        url;
+                    return null;
+                },
+            });
+        });
+
+        const controls = page.locator('.dc-controls');
+        const markdownMenu = controls.locator('.g-dropdown-menu__switcher-wrapper');
+
+        await expect(markdownMenu).toHaveCount(1);
+        await markdownMenu.click();
+
+        const copyAction = page.getByRole('menuitem', {name: 'Copy as Markdown'});
+        const viewAction = page.getByRole('menuitem', {name: 'View as Markdown'});
+
+        await expect(copyAction).toBeVisible();
+        await expect(viewAction).toBeVisible();
+
+        await viewAction.click();
+        await expect
+            .poll(() =>
+                page.evaluate(
+                    () =>
+                        (window as typeof window & {openedMarkdownUrl?: string}).openedMarkdownUrl,
+                ),
+            )
+            .toBe(markdownUrl);
+
+        await markdownMenu.click();
+        await copyAction.click();
+        await expect
+            .poll(() =>
+                page.evaluate(
+                    () => (window as typeof window & {copiedMarkdown?: string}).copiedMarkdown,
+                ),
+            )
+            .toBe(markdown);
+    });
+
     test('SettingsControl test', async ({page}) => {
         const controls = page.locator('.dc-doc-page__controls');
         const control = controls.locator('button').nth(1);

--- a/src/components/Controls/single-controls/MarkdownControl.tsx
+++ b/src/components/Controls/single-controls/MarkdownControl.tsx
@@ -1,0 +1,91 @@
+import type {DropdownMenuItem} from '@gravity-ui/uikit';
+
+import React, {useCallback, useContext, useMemo} from 'react';
+import {Copy, LogoMarkdown} from '@gravity-ui/icons';
+import {DropdownMenu, Icon} from '@gravity-ui/uikit';
+
+import {useTranslation} from '../../../hooks';
+import {ControlsLayoutContext} from '../ControlsLayout';
+
+export function getMarkdownUrl(currentUrl: string) {
+    const markdownUrl = new URL(currentUrl);
+
+    if (markdownUrl.pathname.endsWith('/')) {
+        markdownUrl.pathname += 'index.md';
+    } else {
+        markdownUrl.pathname = markdownUrl.pathname.replace(/\.(?:html?|md)$/i, '') + '.md';
+    }
+
+    return markdownUrl.toString();
+}
+
+export interface MarkdownControlProps {
+    mdDocsUrl?: string;
+    onClick?: React.MouseEventHandler<HTMLElement>;
+}
+
+const MarkdownControl: React.FC<MarkdownControlProps> = ({mdDocsUrl, onClick}) => {
+    const {t} = useTranslation('markdown-button');
+    const {controlClassName, controlSize} = useContext(ControlsLayoutContext);
+    const resolveMarkdownUrl = useCallback(
+        () => mdDocsUrl || getMarkdownUrl(window.location.href),
+        [mdDocsUrl],
+    );
+
+    const copyMarkdown = useCallback(async () => {
+        const response = await fetch(resolveMarkdownUrl(), {
+            credentials: 'same-origin',
+            headers: {Accept: 'text/markdown'},
+        });
+
+        if (!response.ok || !response.headers.get('content-type')?.includes('text/markdown')) {
+            throw new Error(`Failed to load Markdown: ${response.status}`);
+        }
+
+        await navigator.clipboard.writeText(await response.text());
+    }, [resolveMarkdownUrl]);
+
+    const viewMarkdown = useCallback<NonNullable<DropdownMenuItem<unknown>['action']>>(
+        (event) => {
+            if ('nativeEvent' in event) {
+                onClick?.(event);
+            }
+
+            window.open(resolveMarkdownUrl(), '_blank', 'noopener,noreferrer');
+        },
+        [onClick, resolveMarkdownUrl],
+    );
+
+    const items = useMemo<DropdownMenuItem<unknown>[]>(
+        () => [
+            {
+                text: t('copy-as-markdown'),
+                iconStart: <Icon data={Copy} size={16} />,
+                action: () => {
+                    copyMarkdown().catch(() => undefined);
+                },
+            },
+            {
+                text: t('view-in-markdown'),
+                iconStart: <Icon data={LogoMarkdown} size={16} />,
+                action: viewMarkdown,
+            },
+        ],
+        [copyMarkdown, t, viewMarkdown],
+    );
+
+    return (
+        <DropdownMenu
+            items={items}
+            size={controlSize}
+            switcherWrapperClassName={controlClassName}
+            defaultSwitcherProps={{
+                'aria-label': t('markdown-actions'),
+                view: 'flat-secondary',
+            }}
+            popupProps={{placement: ['bottom-end', 'top-end']}}
+        />
+    );
+};
+
+export default MarkdownControl;

--- a/src/components/Controls/single-controls/index.ts
+++ b/src/components/Controls/single-controls/index.ts
@@ -2,6 +2,7 @@ export {default as FullScreenControl} from './FullScreenControl';
 export {default as SettingsControl} from './SettingsControl/SettingsControl';
 export {default as SinglePageControl} from './SinglePageControl';
 export {default as LangControl} from './LangControl/LangControl';
+export {default as MarkdownControl} from './MarkdownControl';
 export {default as DividerControl} from './DividerControl/DividerControl';
 export {default as PdfControl} from './PdfControl';
 export {default as EditControl} from './EditControl';

--- a/src/components/DocPage/DocPage.tsx
+++ b/src/components/DocPage/DocPage.tsx
@@ -779,6 +779,8 @@ class DocPage extends React.Component<DocPageInnerProps, DocPageState> {
             hideEditControl,
             hideFeedbackControls,
             availableLangs = [],
+            mdDocsUrl,
+            onMdDocsButtonClick,
         } = this.props;
 
         if (hideControls) {
@@ -818,6 +820,9 @@ class DocPage extends React.Component<DocPageInnerProps, DocPageState> {
                         availableLangs={availableLangs}
                         pdfLink={headerPdfLink}
                         pdfIconConfig={headerPdfIconConfig}
+                        showMarkdownActions
+                        mdDocsUrl={mdDocsUrl}
+                        onMdDocsButtonClick={onMdDocsButtonClick}
                     />
                 </ControlsLayout>
             </div>

--- a/src/i18n/ar.json
+++ b/src/i18n/ar.json
@@ -162,6 +162,8 @@
     "versions-select-placeholder": "الإصدارات"
   },
   "markdown-button": {
+    "markdown-actions": "إجراءات Markdown",
+    "copy-as-markdown": "نسخ بتنسيق Markdown",
     "view-in-markdown": "عرض في Markdown"
   }
 }

--- a/src/i18n/bg.json
+++ b/src/i18n/bg.json
@@ -161,6 +161,8 @@
     "versions-select-placeholder": "Версии"
   },
   "markdown-button": {
+    "markdown-actions": "Действия с Markdown",
+    "copy-as-markdown": "Копиране като Markdown",
     "view-in-markdown": "Преглед в Markdown"
   }
 }

--- a/src/i18n/cs.json
+++ b/src/i18n/cs.json
@@ -162,6 +162,8 @@
     "versions-select-placeholder": "Verze"
   },
   "markdown-button": {
+    "markdown-actions": "Akce Markdown",
+    "copy-as-markdown": "Kopírovat jako Markdown",
     "view-in-markdown": "Zobrazit v Markdown"
   }
 }

--- a/src/i18n/el.json
+++ b/src/i18n/el.json
@@ -162,6 +162,8 @@
     "versions-select-placeholder": "Εκδόσεις"
   },
   "markdown-button": {
+    "markdown-actions": "Ενέργειες Markdown",
+    "copy-as-markdown": "Αντιγραφή ως Markdown",
     "view-in-markdown": "Προβολή σε Markdown"
   }
 }

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -162,6 +162,8 @@
     "versions-select-placeholder": "Versions"
   },
   "markdown-button": {
-    "view-in-markdown": "View in Markdown"
+    "markdown-actions": "Markdown actions",
+    "copy-as-markdown": "Copy as Markdown",
+    "view-in-markdown": "View as Markdown"
   }
 }

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -162,6 +162,8 @@
     "versions-select-placeholder": "Versiones"
   },
   "markdown-button": {
+    "markdown-actions": "Acciones de Markdown",
+    "copy-as-markdown": "Copiar como Markdown",
     "view-in-markdown": "Ver en Markdown"
   }
 }

--- a/src/i18n/et.json
+++ b/src/i18n/et.json
@@ -162,6 +162,8 @@
     "versions-select-placeholder": "Versioonid"
   },
   "markdown-button": {
+    "markdown-actions": "Markdowni toimingud",
+    "copy-as-markdown": "Kopeeri Markdownina",
     "view-in-markdown": "Vaata Markdownis"
   }
 }

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -162,6 +162,8 @@
     "versions-select-placeholder": "Versions"
   },
   "markdown-button": {
+    "markdown-actions": "Actions Markdown",
+    "copy-as-markdown": "Copier en Markdown",
     "view-in-markdown": "Voir en Markdown"
   }
 }

--- a/src/i18n/he.json
+++ b/src/i18n/he.json
@@ -162,6 +162,8 @@
     "versions-select-placeholder": "גרסאות"
   },
   "markdown-button": {
+    "markdown-actions": "פעולות Markdown",
+    "copy-as-markdown": "העתקה כ-Markdown",
     "view-in-markdown": "הצג ב-Markdown"
   }
 }

--- a/src/i18n/kk.json
+++ b/src/i18n/kk.json
@@ -162,6 +162,8 @@
     "versions-select-placeholder": "Нұсқалар"
   },
   "markdown-button": {
+    "markdown-actions": "Markdown әрекеттері",
+    "copy-as-markdown": "Markdown ретінде көшіру",
     "view-in-markdown": "Markdown-да қарау"
   }
 }

--- a/src/i18n/pt.json
+++ b/src/i18n/pt.json
@@ -162,6 +162,8 @@
     "versions-select-placeholder": "Versões"
   },
   "markdown-button": {
+    "markdown-actions": "Ações de Markdown",
+    "copy-as-markdown": "Copiar como Markdown",
     "view-in-markdown": "Ver em Markdown"
   }
 }

--- a/src/i18n/ru.json
+++ b/src/i18n/ru.json
@@ -163,6 +163,8 @@
     "versions-select-placeholder": "Версии"
   },
   "markdown-button": {
-    "view-in-markdown": "Открыть в Markdown"
+    "markdown-actions": "Действия с Markdown",
+    "copy-as-markdown": "Скопировать как Markdown",
+    "view-in-markdown": "Открыть Markdown"
   }
 }

--- a/src/i18n/tr.json
+++ b/src/i18n/tr.json
@@ -162,6 +162,8 @@
     "versions-select-placeholder": "Sürümler"
   },
   "markdown-button": {
+    "markdown-actions": "Markdown işlemleri",
+    "copy-as-markdown": "Markdown olarak kopyala",
     "view-in-markdown": "Markdown'da görüntüle"
   }
 }

--- a/src/i18n/uz.json
+++ b/src/i18n/uz.json
@@ -162,6 +162,8 @@
     "versions-select-placeholder": "Versiyalar"
   },
   "markdown-button": {
+    "markdown-actions": "Markdown amallari",
+    "copy-as-markdown": "Markdown sifatida nusxalash",
     "view-in-markdown": "Markdown'da ko'rish"
   }
 }

--- a/src/i18n/zh-tw.json
+++ b/src/i18n/zh-tw.json
@@ -162,6 +162,8 @@
     "versions-select-placeholder": "版本"
   },
   "markdown-button": {
+    "markdown-actions": "Markdown 動作",
+    "copy-as-markdown": "複製為 Markdown",
     "view-in-markdown": "在 Markdown 中檢視"
   }
 }

--- a/src/i18n/zh.json
+++ b/src/i18n/zh.json
@@ -162,6 +162,8 @@
     "versions-select-placeholder": "版本"
   },
   "markdown-button": {
+    "markdown-actions": "Markdown 操作",
+    "copy-as-markdown": "复制为 Markdown",
     "view-in-markdown": "在 Markdown 中查看"
   }
 }


### PR DESCRIPTION
## Description

Adds a Markdown actions dropdown to document controls with “Copy as Markdown” and “View as Markdown” options. The dropdown is displayed when `mdDocsUrl` is provided and includes translations for all supported languages. The previous standalone Markdown button below the document title has been removed.