### PR TITLE
fix: add hasMarkdownCompanion check

### DIFF
--- a/src/components/DocPage/DocPage.tsx
+++ b/src/components/DocPage/DocPage.tsx
@@ -295,6 +295,16 @@ class DocPage extends React.Component<DocPageInnerProps, DocPageState> {
         return name in map ? !map[name] : false;
     }
 
+    private get hasMarkdownCompanion(): boolean {
+        const {mdDocsUrl, meta} = this.props;
+        const hasMarkdownAlternate = meta.alternate?.some(
+            ({type, title}) => type === 'text/markdown' && title === 'Markdown version',
+        );
+        const hasMarkdownVcsPath = /\.md$/i.test(meta.vcsPath || '');
+
+        return Boolean(mdDocsUrl || hasMarkdownAlternate || hasMarkdownVcsPath);
+    }
+
     private handleBodyMutation = (mutationsList: MutationRecord[]) => {
         const {onContentMutation, onContentLoaded} = this.props;
 
@@ -820,7 +830,7 @@ class DocPage extends React.Component<DocPageInnerProps, DocPageState> {
                         availableLangs={availableLangs}
                         pdfLink={headerPdfLink}
                         pdfIconConfig={headerPdfIconConfig}
-                        showMarkdownActions
+                        showMarkdownActions={this.hasMarkdownCompanion}
                         mdDocsUrl={mdDocsUrl}
                         onMdDocsButtonClick={onMdDocsButtonClick}
                     />

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -126,6 +126,7 @@ export interface DocMeta {
     updatedAt?: string;
     canonical?: string;
     alternate?: Alternate[];
+    vcsPath?: string;
     tags?: string[];
 }
 
@@ -192,6 +193,8 @@ export interface LangOptions {
 export type Alternate = {
     href: string;
     hreflang?: string;
+    type?: string;
+    title?: string;
 };
 
 export interface Contributor {


### PR DESCRIPTION
## Description

Added a check that dropdown is shown only when a Markdown companion is detected via mdDocsUrl, meta.alternate, or a .md value in meta.vcsPath. 
